### PR TITLE
Make beats start independently from all or core

### DIFF
--- a/swirl.py
+++ b/swirl.py
@@ -483,7 +483,10 @@ def main(argv):
         if service_list == [] or service_list[0].lower() == 'all':
             service_list = []
             for service in SERVICES:
-                service_list.append(service['name'])
+                # only add default services, since none was specified
+                if 'default' in service:
+                    if service['default']:
+                        service_list.append(service['name'])
         elif service_list[0].lower() == 'core':
             service_list = SWIRL_CORE_SERVICES
         else:

--- a/swirl/services.py
+++ b/swirl/services.py
@@ -14,19 +14,23 @@ module_name = 'services.py'
 SWIRL_SERVICES = [
     {
         'name': 'rabbitmq',
-        'path': 'rabbitmq-server'
+        'path': 'rabbitmq-server',
+        'default': True
     },
     {
         'name': 'django',
-        'path': 'daphne -b 0.0.0.0 -p 8000 swirl_server.asgi:application'
+        'path': 'daphne -b 0.0.0.0 -p 8000 swirl_server.asgi:application',
+        'default': True
     },
     {
         'name': 'celery-worker',
-        'path': 'celery -A swirl_server worker --loglevel INFO'
+        'path': 'celery -A swirl_server worker --loglevel INFO',
+        'default': True
     },
     {
         'name': 'celery-beats',
-        'path': 'celery -A swirl_server beat --scheduler django_celery_beat.schedulers:DatabaseScheduler'
+        'path': 'celery -A swirl_server beat --scheduler django_celery_beat.schedulers:DatabaseScheduler',
+        'default': False
     }
 ]
 
@@ -41,19 +45,24 @@ SERVICES_DICT = SWIRL_SERVICES_DICT
 SWIRL_SERVICES_DEBUG = [
     {
         'name': 'rabbitmq',
-        'path': 'rabbitmq-server'
+        'path': 'rabbitmq-server',
+        'default': True
+
     },
     {
         'name': 'django',
-        'path': 'python manage.py runserver'
+        'path': 'python manage.py runserver',
+        'default': True
     },
     {
         'name': 'celery-worker',
-        'path': 'celery -A swirl_server worker --loglevel DEBUG'
+        'path': 'celery -A swirl_server worker --loglevel DEBUG',
+        'default': True
     },
     {
         'name': 'celery-beats',
-        'path': 'celery -A swirl_server beat --scheduler django_celery_beat.schedulers:DatabaseScheduler'
+        'path': 'celery -A swirl_server beat --scheduler django_celery_beat.schedulers:DatabaseScheduler',
+        'default': False
     }
 ]
 


### PR DESCRIPTION
Added 'default' key to services list including debug - swirl/services.py
Set celery-beats to 'default': False
Modified swirl.py to load only services with 'default': True
This is the fix for DS-666
Hey that rhymes!