### PR TITLE
Update Readme and banner for release 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1>&nbsp; Swirl Metasearch 2.2<img alt='Swirl Metasearch Logo' src='https://raw.githubusercontent.com/wiki/swirlai/swirl-search/images/swirl-logo-only-blue.png' width=38 align=left /></h1>
+<h1>&nbsp; Swirl Metasearch 2.5<img alt='Swirl Metasearch Logo' src='https://raw.githubusercontent.com/wiki/swirlai/swirl-search/images/swirl-logo-only-blue.png' width=38 align=left /></h1>
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?color=blue&logoColor=blue&style=flat)](https://opensource.org/license/apache-2-0/)
 [![GitHub Release](https://img.shields.io/github/v/release/swirlai/swirl-search?style=flat&label=Release)](https://github.com/swirlai/swirl-search/releases)
@@ -39,29 +39,29 @@ After a few minutes the following or similar should appear:
 
 ```
 ssdtest-app-1  | Command successful!
-ssdtest-app-1  | __S_W_I_R_L__2_._2____________________________________________________________
+ssdtest-app-1  | __S_W_I_R_L__2_._5____________________________________________________________
 ssdtest-app-1  |
 ssdtest-app-1  | Warning: logs directory does not exist, creating it
-ssdtest-app-1  | Start: rabbitmq -> rabbitmq-server ... Ok, pid: 53
-ssdtest-app-1  | Start: celery-worker -> celery -A swirl_server worker ... Ok, pid: 577
-ssdtest-app-1  | Start: celery-beats -> celery -A swirl_server beat --scheduler django_celery_beat.schedulers:DatabaseScheduler ... Ok, pid: 609
+ssdtest-app-1  | Start: redis -> redis-server ./redis.conf ... Ok, pid: 28
+ssdtest-app-1  | Start: celery-worker -> celery -A swirl_server worker --loglevel INFO ... Ok, pid: 34
+ssdtest-app-1  | Start: celery-beats -> celery -A swirl_server beat --scheduler django_celery_beat.schedulers:DatabaseScheduler ... Ok, pid: 45
 ssdtest-app-1  | Updating .swirl... Ok
 ssdtest-app-1  |
 ssdtest-app-1  |   PID TTY          TIME CMD
-ssdtest-app-1  |    53 ?        00:00:00 rabbitmq-server
-ssdtest-app-1  |   577 ?        00:00:11 celery
-ssdtest-app-1  |   609 ?        00:00:06 celery
+ssdtest-app-1  |    28 ?        00:00:00 redis-server
+ssdtest-app-1  |    34 ?        00:00:02 celery
+ssdtest-app-1  |    45 ?        00:00:02 celery
 ssdtest-app-1  |
 ssdtest-app-1  | Command successful!
-ssdtest-app-1  | 2023-08-06 13:16:11,070 INFO     Starting server at tcp:port=8000:interface=0.0.0.0
-ssdtest-app-1  | 2023-08-06 13:16:11,074 INFO     HTTP/2 support not enabled (install the http2 and tls Twisted extras)
-ssdtest-app-1  | 2023-08-06 13:16:11,075 INFO     Configuring endpoint tcp:port=8000:interface=0.0.0.0
-ssdtest-app-1  | 2023-08-06 13:16:11,079 INFO     Listening on TCP address 0.0.0.0:8000
+ssdtest-app-1  | 2023-08-03 13:16:11,070 INFO     Starting server at tcp:port=8000:interface=0.0.0.0
+ssdtest-app-1  | 2023-08-03 13:16:11,074 INFO     HTTP/2 support not enabled (install the http2 and tls Twisted extras)
+ssdtest-app-1  | 2023-08-03 13:16:11,075 INFO     Configuring endpoint tcp:port=8000:interface=0.0.0.0
+ssdtest-app-1  | 2023-08-03 13:16:11,079 INFO     Listening on TCP address 0.0.0.0:8000
 ```
 
 * Open this URL with a browser: http://localhost:8000 (or http://localhost:8000/galaxy/)
 
-The search page will appear. Click `Log Out` at top, right. The Swirl login page will appear:
+ If the search page appears. Click `Log Out` at top, right. The Swirl login page will appear:
 
 ![Swirl Login](https://raw.githubusercontent.com/wiki/swirlai/swirl-search/images/swirl_login-galaxy_dark.png)
 
@@ -77,7 +77,7 @@ Enter username `admin` and password `password`. Then click Login.
 
 :key: Using Swirl with Microsoft 365 requires installation and approval by an authorized company administrator. For more information please review the [M365 Guide](https://github.com/swirlai/swirl-search/wiki/4.-M365-Guide) or [contact us](mailto:hello@swirl.today) for more information.
 
-### Learn more: [Quick Start](https://github.com/swirlai/swirl-search/wiki/1.-Quick-Start)
+#### Want to install Swirl locally?  Want to run it in Docker on a Windows laptop? Check out the [Quick Start Guide](https://github.com/swirlai/swirl-search/wiki/1.-Quick-Start)!
 
 <br/>
 
@@ -91,7 +91,7 @@ Enter username `admin` and password `password`. Then click Login.
 
 | Version                     | Date                        | Notes |
 | --------------------------- | --------------------------- | ----- |
-| [Swirl Metasearch 2.1](https://github.com/swirlai/swirl-search/releases/tag/v2.1.0) | 07-06-2023 | [Release 2.0](https://github.com/swirlai/swirl-search/releases) |
+| [Swirl Metasearch 2.5](https://github.com/swirlai/swirl-search/releases/tag/v2.5.0) | 08-03-2023 | [Release 2.5](https://github.com/swirlai/swirl-search/releases) |
 
 <br/>
 
@@ -143,6 +143,6 @@ Enter username `admin` and password `password`. Then click Login.
 
 * [Join the Swirl Metasearch Community on Slack!](https://join.slack.com/t/swirlmetasearch/shared_invite/zt-1qk7q02eo-kpqFAbiZJGOdqgYVvR1sfw)
 
-* Email: [support@swirl.today](mailto:support@swirl.today) with issues, requests, questions, etc - we'd love to hear from you!
+* Email: [support@swirl.today](mailto:support@swirl.today) with issues, requests, questions, etc. - we'd love to hear from you!
 
 <br/>

--- a/swirl/banner.py
+++ b/swirl/banner.py
@@ -10,9 +10,9 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
 
-SWIRL_VERSION = '2.2'
+SWIRL_VERSION = '2.5'
 
-SWIRL_BANNER_TEXT = "__S_W_I_R_L__2_._2______________________________________________________________"
+SWIRL_BANNER_TEXT = "__S_W_I_R_L__2_._5______________________________________________________________"
 SWIRL_BANNER = f'{bcolors.BOLD}{SWIRL_BANNER_TEXT}{bcolors.ENDC}'
 
 #############################################


### PR DESCRIPTION
- Update swirl/banner.py to version 2.5
- First pass updating README for 2.5; will finalize when we're ready to release

DS-718