### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ RUN apt-file update
 RUN apt-get install -y python3-dev build-essential
 RUN apt-get install -y procps
 
-RUN pip install --upgrade pip
-RUN pip install --upgrade grpcio
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir --upgrade grpcio
 
 ADD requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # install redis
 RUN apt-get install -y redis-server


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages by pip don't cached on system . This is a best practice which make sure to fetch from repo instead of using local cached one . Further , in case of Docker Containers , by restricting caching , we can reduce image size. In term of stats , it depends upon the number of python packages multiplied by their respective size . e.g for heavy packages with a lot of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

DS-758