### PR TITLE
add remote-theme gem for GH Pages publishing issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem "webrick"
+gem "jekyll-remote-theme"
 gem "jekyll-default-layout"
 gem 'jekyll-include-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ DEPENDENCIES
   github-pages
   jekyll-default-layout
   jekyll-include-cache
+  jekyll-remote-theme
   webrick
 
 BUNDLED WITH


### PR DESCRIPTION
## Branching
Always branch off from the `develop` branch with a descriptive name that encapsulates your idea or fix. This practice helps ensure that our `main` branch remains stable.

<!--- Provide a general summary of your changes in the TITLE above -->

## Description
<!--- Describe your changes in detail -->
Add the jekyll-remote-theme gem to the Gemfile; for some reason the build worked locally, but it doesn't get the remote theme correctly at GH Pages.  Hoping this will remedy that issue.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them here. -->


## Testing and Validation
<!--- Please describe in detail how you tested your changes, including details of your testing environment and the tests you ran to validate your change, etc. -->
Can't really; it's always worked locally.

## Screenshots (if appropriate):


## Documentation
<!-- Please note any proposed updates to the repo Readme file or the product documentation to support this PR. -->
see above

## Changes Include
<!-- Check all that apply to this PR. -->
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [x] Documentation (change to product documentation or Readme.md only)


## PR Checklist
- [ ] This PR targets the `develop` branch of the [swirl-search](https://github.com/swirlai/swirl-search) repo. --> N/A
- [x] The above portion of this template is filled out completely.
- [x] This PR has been tested for correct functionality and validated not to break existing product code.
