### PR TITLE
remove excludes from docs config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -78,19 +78,6 @@ search:
   # Supports true or false (default)
   button: false
 
-exclude:
- # from https://github.com/jekyll/jekyll/blob/master/lib/site_template/_config.yml:
-   - .sass-cache/
-   - .jekyll-cache/
-   - gemfiles/
-   - Gemfile
-   - Gemfile.lock
-   - node_modules/
-   - vendor/bundle/
-   - vendor/cache/
-   - vendor/gems/
-   - vendor/ruby/
-
 # Build settings
 markdown: kramdown
 remote_theme: "just-the-docs/just-the-docs"


### PR DESCRIPTION
Chasing down a docs GH Pages publishing issue: removing the excludes from `_config.yml` (don't really need them, most likely).