### PR TITLE
disable .jekyll-cache and add some excludes back to build config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -82,6 +82,17 @@ theme: just-the-docs
 plugins:
   - jekyll-default-layout
   - jemoji
+disable_disk_cache: true
+
+exclude:
+ # Modified from https://github.com/jekyll/jekyll/blob/master/lib/site_template/_config.yml:
+   - .sass-cache/
+   - .jekyll-cache/
+   - node_modules/
+   - vendor/bundle/
+   - vendor/cache/
+   - vendor/gems/
+   - vendor/ruby/
 
 # Kramdown settings
 kramdown:


### PR DESCRIPTION
Jekyll config updates to disable .jekyll-cache and also to add back some excludes (to skip in the site conversion process)