### PR TITLE
remove title from google verification page

### DIFF
--- a/docs/googlec95caf0bd4a8c5df.html
+++ b/docs/googlec95caf0bd4a8c5df.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: Docker Build
 nav_exclude: true
 search_exclude: true
 ---


### PR DESCRIPTION
removed the `title` param from the front-matter of the google verification page