### PR TITLE
add guide titles back to main content

### DIFF
--- a/docs/1.-Quick-Start.md
+++ b/docs/1.-Quick-Start.md
@@ -12,7 +12,9 @@ nav_order: 2
 {:toc}
 </details>
 
-# Intended Audience
+# Quick Start Guide
+
+## Intended Audience
 
 This guide is intended for anyone who wants to download and install Swirl Metasearch. 
 

--- a/docs/2.-User-Guide.md
+++ b/docs/2.-User-Guide.md
@@ -12,7 +12,9 @@ nav_order: 3
 {:toc}
 </details>
 
-# Intended Audience
+# User Guide
+
+## Intended Audience
 
 This guide is intended for developers, data scientists, program managers, or anyone who wants to use Swirl Metasearch, including searching and customizing SearchProviders. 
 

--- a/docs/3.-Admin-Guide.md
+++ b/docs/3.-Admin-Guide.md
@@ -12,7 +12,9 @@ nav_order: 4
 {:toc}
 </details>
 
-# Intended Audience
+# Admin Guide
+
+## Intended Audience
 
 This guide is intended for developers and system administrators who want to harden/configure Swirl Metasearch for production use.
 

--- a/docs/4.-M365-Guide.md
+++ b/docs/4.-M365-Guide.md
@@ -12,7 +12,9 @@ nav_order: 5
 {:toc}
 </details>
 
-# Intended Audience
+# Microsoft 365 Guide
+
+## Intended Audience
 
 This guide details how to integrate Swirl Metasearch (v. 2.0 or newer) with an existing Microsoft 365 (M365) tenant. It is intended for use by M365 Administrators with authority to add a new App Registration in their Azure Portal and optionally grant permissions for various APIs as noted below on behalf of users who wish to use Swirl Metasearch to query their personal M365 content.
 

--- a/docs/5.-Developer-Guide.md
+++ b/docs/5.-Developer-Guide.md
@@ -12,7 +12,9 @@ nav_order: 6
 {:toc}
 </details>
 
-# Intended Audience
+# Developer Guide
+
+## Intended Audience
 
 This guide is intended to provide developers with an overview of Swirl and how to accomplish specific tasks with it. Please refer to the [Developer Reference](6.-Developer-Reference.md) for lists of system states, system objects and properties, etc.
 

--- a/docs/6.-Developer-Reference.md
+++ b/docs/6.-Developer-Reference.md
@@ -12,7 +12,9 @@ nav_order: 7
 {:toc}
 </details>
 
-# Intended Audience
+# Developer Reference
+
+## Intended Audience
 
 This guide is intended to provide developers with detailed reference information about Swirl. Please refer to the [Developer Guide](5.-Developer-Guide.md) for an overview of how to work with Swirl.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,9 @@ nav_order: 1
 {:toc}
 </details>
 
-# What is Metasearch? Is it the same as Federated Search?
+# Swirl Overview
+
+## What is Metasearch? Is it the same as Federated Search?
 
 [Metasearch](https://en.wikipedia.org/wiki/Federated_search) is a technical approach in which a search engine (or "broker") accepts a query from some user (or system), distributes the query to other search engines, waits for the responses, then returns a normalized, unified and ideally relevancy-ranked set of results.
 
@@ -22,7 +24,7 @@ The metasearch approach differs from traditional [enterprise search engines](htt
 
 Metasearch leaves the source data in place and relies on each source's own search engine to get access. This makes federated search less suited for deep navigation - across a large e-commerce or data set catalog, for example - but ideal for delivering cross-silo results with a fraction of the effort. It is also excellent for information enrichment, entity analysis (such as competitive, customer, industry or market intelligence) and integrating unstructured data for content curation, data science and machine learning applications.
 
-# What is Swirl Metasearch?
+## What is Swirl Metasearch?
 
 [Swirl Metasearch](https://github.com/swirlai/swirl-search) is a metasearch engine built on the Python/Django stack and released under the Apache 2.0 license in 2022.
 


### PR DESCRIPTION
Add the guide titles back into the main content (to match page titles)