### PR TITLE
add auto-run trigger for docs/ dir changes only

### DIFF
--- a/.github/workflows/urls-checker.yml
+++ b/.github/workflows/urls-checker.yml
@@ -1,6 +1,14 @@
 name: Check URLs
 
+# Trigger to only run this workflow automatically on docs/ directory changes
 on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "docs/**"
+
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Trigger to automatically run this workflow on changes merged to the `docs/` directory only (same syntax as pages.yml, fwiw).