### PR TITLE
docs: fix typo in docs/2.-User-Guide.md

### DIFF
--- a/docs/2.-User-Guide.md
+++ b/docs/2.-User-Guide.md
@@ -484,7 +484,7 @@ The following table summarizes the `response_mappings` options:
 | Mapping | Source_JSONPath | Required? | Example | 
 | ---------- | ---------- | ---------- | ---------- |
 | FOUND | Number of results for a given query, for this SearchProvider, e.g. 1,413<br/>Same as `RETRIEVED` if not specified | No | `searchInformation.totalResults=FOUND` |
-| RETRIEVED | Number of results returned for a given query, for this SearchProvider, e.g. 10<br/>Lengh of the `RESULTS` list (see below) if not specified | No | `queries.request[0].count=RETRIEVED` |
+| RETRIEVED | Number of results returned for a given query, for this SearchProvider, e.g. 10<br/>Length of the `RESULTS` list (see below) if not specified | No | `queries.request[0].count=RETRIEVED` |
 | RESULTS | Path to the list of Result items | Yes | `items=RESULTS` |
 | RESULT | Path to the document, if Result items are a dictionary/wrapper | No | `document=RESULT` |
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
This pull request fixes typo `Lengh -> Length` in the user guide documentation.

## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [x] Documentation (change to product documentation or README.md only)