### PR TITLE
fix for relative .md links in the docs

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem 'jekyll', '~> 4.3.2' # installed by `gem jekyll`
 gem 'jekyll-default-layout'
 gem 'jekyll-sitemap'
+gem 'jekyll-relative-links'
 gem 'jemoji'
 gem 'just-the-docs'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
       jekyll (>= 3.0, < 5.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-relative-links (0.7.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
@@ -117,6 +119,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.3.2)
   jekyll-default-layout
+  jekyll-relative-links
   jekyll-sitemap
   jemoji
   just-the-docs

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -76,12 +76,17 @@ search:
   # Supports true or false (default)
   button: false
 
+relative_links:
+  enabled:     true
+  collections: false
+
 # Build settings
 markdown: kramdown
 theme: just-the-docs
 plugins:
   - jekyll-default-layout
   - jekyll-sitemap
+  - jekyll-relative-links
   - jemoji
 disable_disk_cache: true
 


### PR DESCRIPTION
Fix to the build process for all relative links containing `.md` in the documentation.