### PR TITLE
move updated spell check config over from main

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -2,3 +2,7 @@
 
 [files]
 extend-exclude = ["swirl/tests/"]
+
+[default.extend-identifiers]
+# Don't correct this variable from scripts/fix_csv.py
+fo = "fo"


### PR DESCRIPTION
Excludes a variable name from spell check that was always hitting as a misspelled.