### PR TITLE
Update README.md - fix grammatrical errors in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@
 
 </div>
 
-Swirl is open source software that simultaneously searches multiple content sources and returns AI ranked results. Prompt your choice of Generative AI using the top N results to get answers incorporating your own data.
+Swirl is an open source software that simultaneously searches multiple content sources and returns AI ranked results. Prompt your choice of Generative AI using the top N results to get answers incorporating your own data.
 
 Swirl can connect to:
 
 * Databases (SQL & NoSQL, Google BigQuery)
 * Public data services (Google Programmable Search, Arxiv.org, etc.)
-* Enterprise sources (Microsoft 365, Jira, Miro etc.)
+* Enterprise sources (Microsoft 365, Jira, Miro, etc.)
 
 And generate insights with AI and LLMs like ChatGPT. Start discovering and generating the answers you need based on your data.
 


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**Swirl**"

"**Swirl is open source **"  should be "**Swirl is an open source **"

" **365, Jira, Miro etc**"  should be " **365, Jira, Miro, etc**"

Screenshot-

![Screenshot (139)](https://github.com/swirlai/swirl-search/assets/115995339/21458df8-58be-48ef-809e-354c4a213c37)
