### PR TITLE
workflow updates and consolidation on main

### DIFF
--- a/.github/workflows/docker-image-spg-experimental.yml
+++ b/.github/workflows/docker-image-spg-experimental.yml
@@ -1,7 +1,7 @@
-name: EXPERIMENTAL Latest Spyglass Docker Build
+name: EXPERIMENTALSpyglassDockerBuild
 
 on:
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 # For debugging
@@ -12,7 +12,6 @@ on:
 jobs:
 
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +19,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Build the Docker image
       run: docker build --no-cache -t swirlai/spyglass:fork-x  -f Dockerfile.fork.spg .
-    - name: login to docker hub
+    - name: Login to docker hub
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
     - name: Push the Docker image
       run: docker push swirlai/spyglass:fork-x

--- a/.github/workflows/docker-image-spg-preview.yml
+++ b/.github/workflows/docker-image-spg-preview.yml
@@ -1,7 +1,12 @@
-name: PREVIEW Latest Spyglass Docker Build
+name: PREVIEWSpyglassDockerBuild
 
 on:
-  # Allows you to run this workflow manually from the Actions tab
+  # Run this workflow automatically if IntegrationAPITests completed successfully
+  workflow_run:
+    workflows: [IntegrationAPITests]
+    types: 
+      - completed
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 # For debugging
@@ -10,17 +15,23 @@ on:
 #     branches: ''
 
 jobs:
-
   build:
-
+    # Run this workflow automatically only on develop (see last line of the 'if' statement)
+    if: >
+      github.event_name == 'workflow_dispatch' || 
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' && 
+       github.event.workflow_run.head_branch == 'develop')
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout the code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.workflow_run.head_branch }}
     - name: Build the Docker image
       run: docker build --no-cache -t swirlai/spyglass:preview  -f Dockerfile.develop.spg .
-    - name: login to docker hub
+    - name: Login to docker hub
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
     - name: Push the Docker image
       run: docker push swirlai/spyglass:preview

--- a/.github/workflows/docker-image-spg.yml
+++ b/.github/workflows/docker-image-spg.yml
@@ -1,11 +1,12 @@
 name: LatestSpyglassDockerBuild
 
 on:
+  # Run this workflow automatically if IntegrationAPITests completed successfully
   workflow_run:
     workflows: [IntegrationAPITests]
     types: 
       - completed
-  # Allow manual run of this workflow from the Actions tab
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 # For debugging
@@ -14,55 +15,26 @@ on:
 #     branches: ''
 
 jobs:
-
   build:
-    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    # Run this workflow automatically only on main (see last line of the 'if' statement)
+    if: >
+      github.event_name == 'workflow_dispatch' || 
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' && 
+       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
 
     steps:
-    - name: Download branch and run_id artifacts
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: integration-api-tests.yml
-        name: branch-info-${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || github.run_id }}
-        path: ./artifacts
-      continue-on-error: true # Allow the step to fail without stopping the workflow
-    - name: Determine branch for checkout
-      id: determine_branch
-      run: |
-        if [[ -f ./artifacts/branch.txt && -f ./artifacts/run_id.txt ]]; then
-          echo "branch=$(cat ./artifacts/branch.txt)" >> $GITHUB_ENV
-          echo "original_run_id=$(cat ./artifacts/run_id.txt)" >> $GITHUB_ENV
-        else
-          BRANCH_NAME=$(echo $GITHUB_REF | cut -d "/" -f 3)
-          echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
-        fi
-    - name: Print branch to be checked out
-      run: |
-        echo "Branch to checkout: ${{ env.branch }}"
     - name: Checkout the code
       uses: actions/checkout@v4
       with:
-        ref: ${{ env.branch }}
+        ref: ${{ github.event.workflow_run.head_branch }}
     - name: Build the Docker image
-      run: docker build --no-cache -t swirlai/spyglass:latest  -f Dockerfile.spg .
-    - name: login to docker hub
+      run: docker build --no-cache -t swirlai/spyglass:latest -f Dockerfile.spg .
+    - name: Login to docker hub
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
     - name: Push the Docker image
       run: docker push swirlai/spyglass
-    - name: Ensure artifacts directory exists and write branch and run_id again
-      run: |
-        mkdir -p ./artifacts
-        echo "${{ env.branch }}" > ./artifacts/branch.txt
-        echo "${{ env.original_run_id }}" > ./artifacts/run_id.txt
-    - name: Re-upload branch and run_id for subsequent workflows
-      uses: actions/upload-artifact@v3
-      with:
-        name: branch-info-${{ github.run_id }}
-        path: |
-          ./artifacts/branch.txt
-          ./artifacts/run_id.txt
     - name: Upload log files
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,11 +1,7 @@
 name: DockerBuild
 
 on:
-  workflow_run:
-    workflows: [LatestSpyglassDockerBuild]
-    types: 
-      - completed
-  # Allow manual run of this workflow from the Actions tab
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 # For debugging
@@ -16,35 +12,11 @@ on:
 jobs:
 
   build:
-    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
 
     steps:
-    - name: Download branch and run_id artifacts
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: docker-image-spg.yml
-        name: branch-info-${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || github.run_id }}
-        path: ./artifacts
-      continue-on-error: true # Allow the step to fail without stopping the workflow
-    - name: Determine branch for checkout
-      id: determine_branch
-      run: |
-        if [[ -f ./artifacts/branch.txt && -f ./artifacts/run_id.txt ]]; then
-          echo "branch=$(cat ./artifacts/branch.txt)" >> $GITHUB_ENV
-          echo "original_run_id=$(cat ./artifacts/run_id.txt)" >> $GITHUB_ENV
-        else
-          BRANCH_NAME=$(echo $GITHUB_REF | cut -d "/" -f 3)
-          echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
-        fi
-    - name: Print branch to be checked out
-      run: |
-        echo "Branch to checkout: ${{ env.branch }}"
     - name: Checkout the code
       uses: actions/checkout@v4
-      with:
-        ref: ${{ env.branch }}
     - name: login to docker hub
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
     - name: pull latest UI image

--- a/.github/workflows/integration-api-tests.yml
+++ b/.github/workflows/integration-api-tests.yml
@@ -1,11 +1,12 @@
 name: IntegrationAPITests
 
 on:
+  # Run this workflow automatically if SmokeTests completed successfully
   workflow_run:
     workflows: [SmokeTests]
     types:
       - completed
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 jobs:
@@ -40,26 +41,26 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.branch }}
-    - name: Set up Python
+    - name: Setup Python
       uses: actions/setup-python@v4
       with:
             python-version: '3.11'
             cache: 'pip' # caching pip stuff
-    - name: Run Install Swirl
+    - name: Install Swirl
       run: ./install.sh
     - name: Update apt
       run: sudo apt -o Acquire::Retries=3 update
-    - name: upgrade Ubuntu to latest patches
+    - name: Upgrade Ubuntu to latest patches
       run: sudo apt upgrade -y
-    - name: stop update-notifier which restarts datetime
+    - name: Stop the update-notifier which restarts datetime
       run: sudo systemctl stop update-notifier-download.timer
-    - name: disable update-notifier which restarts datetime
+    - name: Disable the update-notifier which restarts datetime
       run: sudo systemctl disable update-notifier-download.timer
-    - name: Run Install redist-server
+    - name: Install redis-server
       run: sudo apt install -y redis-server
-    - name: Set up Swirl
+    - name: Setup Swirl
       run: python swirl.py setup
-    - name: Start up Swirl
+    - name: Start Swirl
       run: python swirl.py start
     - name: Run Integrated API tests
       run: docker run --net=host -t swirlai/swirl-testing:latest-integrated-api sh -c "behave --tags=integrated_api"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@
 # documentation.
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to Pages
+name: DeployDocsSite
 
 # Modified trigger to only start this workflow on docs dir changes
 on:
@@ -14,7 +14,7 @@ on:
     paths:
       - "docs/**"
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/sectest-docker-image.yml
+++ b/.github/workflows/sectest-docker-image.yml
@@ -1,24 +1,26 @@
-name: Security Testing Build
+name: SecurityTestingBuild
 
 # Build a multi-arch docker image for testing security updates to Swirl
 
 on:
   push:
-    # only trigger on branches to security-testing, not on tags
-    branches: 'security-testing'
-
+    # Trigger this workflow on pushes to the following branches
+    branches:
+      - security-testing
+  # Allows manual run of this workflow from the Actions tab (on any branch)
+  workflow_dispatch:
 
 jobs:
 
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: login to docker hub
+    - name: Checkout the code
+      uses: actions/checkout@v4
+    - name: Login to docker hub
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-    - name: builder bootstrap
+    - name: Builder bootstrap
       run: docker buildx create --name devBuilder --use --bootstrap
     - name: Build the Docker image
       run: docker buildx build -t swirlai/swirl-search:security-testing --platform linux/amd64,linux/arm64 --push .

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,11 +1,12 @@
 name: SmokeTests
 
 on:
+  # Run this workflow automatically if UnitTests completed successfully
   workflow_run:
     workflows: [UnitTests]
     types:
       - completed
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 jobs:
@@ -40,24 +41,24 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.branch }}
-    - name: Set up Python
+    - name: Setup Python
       uses: actions/setup-python@v4
       with:
             python-version: '3.11'
             cache: 'pip' # caching pip stuff
-    - name: Run Install Swirl
+    - name: Install Swirl
       run: ./install.sh
     - name: Update apt
       run: sudo apt -o Acquire::Retries=3 update
-    - name: upgrade Ubuntu to latest patches
+    - name: Upgrade Ubuntu to latest patches
       run: sudo apt upgrade -y
-    - name: Run Install redis-server
+    - name: Install redis-server
       run: sudo apt install -y redis-server
-    - name: Set up Swirl
+    - name: Setup Swirl
       run: python swirl.py setup
-    - name: Start up Swirl
+    - name: Start Swirl
       run: python swirl.py start
-    - name: Run Smoke tests
+    - name: Run Smoke Tests
       run: docker run --net=host -t swirlai/swirl-testing:latest-smoke-test sh -c "behave **/docker_container/*.feature --tags=docker_api_smoke"
     - name: Ensure artifacts directory exists and write branch and run_id again
       run: |

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -1,4 +1,4 @@
-name: Check Spelling
+name: CheckSpelling
 
 # Trigger to only run this workflow automatically on docs/ directory changes
 on:
@@ -8,7 +8,7 @@ on:
     paths:
       - "docs/**"
 
-  # Also allow manual run of this workflow from the Actions tab
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,9 +6,11 @@ on:
       - 'docs/**'
       - '.github/**'
       - 'README.md'
-    # Only trigger on branches, not on tags
-    branches: 'main'
-  # Allows you to run this workflow manually from the Actions tab
+    # Trigger this workflow on pushes to the following branches
+    branches:
+      - main
+      - develop
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 jobs:
@@ -24,11 +26,11 @@ jobs:
       with:
             python-version: '3.11'
             cache: 'pip' # caching pip stuff
-    - name: Run Install Swirl
+    - name: Install Swirl
       run: ./install.sh
-    - name: Run Install Tests Swirl
+    - name: Install Tests
       run: ./install-test.sh
-    - name: Run pytest unit tests
+    - name: Run pytest Unit Tests
       run: pytest
     - name: Create artifacts directory
       run: mkdir -p artifacts

--- a/.github/workflows/urls-checker.yml
+++ b/.github/workflows/urls-checker.yml
@@ -1,4 +1,4 @@
-name: Check URLs
+name: CheckURLs
 
 # Trigger to only run this workflow automatically on docs/ directory changes
 on:
@@ -8,7 +8,7 @@ on:
     paths:
       - "docs/**"
 
-  # Also allow manual run of this workflow from the Actions tab
+  # Allows manual run of this workflow from the Actions tab (on any branch)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Updating and consolidating our GitHub workflows as follows (plus some other little clean-ups in the yml files):

GENERAL
- All of our workflow files will live only on `main` branch only (and be removed from `develop` in a separate PR)
- All workflows will have a `workflow_dispatch` directive allowing them to be run manually from the Actions UI on any branch

TESTING + DOCKER BUILDS
- "UnitTests" will be set to trigger on push to either `main` or `develop` branches; if successful, "SmokeTests" will start on the same branch; if that succeeds, "IntegrationAPITests" will start on the same branch.
- "LatestSpyglassDockerBuild" will trigger if "IntegrationAPITests" succeeds on `main` branch only
- "PREVIEWSpyglassDockerBuild" will trigger if "IntegrationAPITests" succeeds on `develop` branch only
- "EXPERIMENTALSpyglassDockerBuild" will be manual trigger only.
- "SecurityTestingBuild" will be manual trigger only

OTHER YMLs
- "DeployDocsSite" (pages.yml) triggers on push to `main` > `docs/` directory only (and manually)
- "CheckSpelling" (spell-checker.yml) triggers on push to `main` > `docs/` directory only (and manually)
- "CheckURLs" (urls-checker.yml) triggers on push to `main` > `docs/` directory only (and manually)