### PR TITLE
Change elastic and opensearch credential format to username:password

### DIFF
--- a/SearchProviders/elastic_cloud.json
+++ b/SearchProviders/elastic_cloud.json
@@ -12,7 +12,7 @@
         "CosineRelevancyResultProcessor"
     ],
     "result_mappings": "url=_source.url,date_published=_source.date_published,author=_source.author,title=_source.subject,body=_source.content,_source.to,NO_PAYLOAD",
-    "credentials": "(\"elastic\", \"elastic-password\")",
+    "credentials": "elastic,elastic-password",
     "tags": [
         "Enron",
         "Elastic",

--- a/SearchProviders/elasticsearch.json
+++ b/SearchProviders/elasticsearch.json
@@ -14,7 +14,7 @@
         "CosineRelevancyResultProcessor"
     ],
     "result_mappings": "url=_source.url,date_published=_source.date_published,author=_source.author,title=_source.subject,body=_source.content,_source.to,NO_PAYLOAD",
-    "credentials": "(\"elastic\", \"elastic-password\")",
+    "credentials": "elastic,elastic-password",
     "tags": [
         "Enron",
         "Elastic",

--- a/swirl/connectors/elastic.py
+++ b/swirl/connectors/elastic.py
@@ -80,10 +80,16 @@ class Elastic(Connector):
 
         auth = None
         if self.provider.credentials:
-            if self.provider.credentials.startswith('http_auth='):
-                auth = self.provider.credentials.split("http_auth=")[1]
-            else:
-                auth = self.provider.credentials
+            # extract auth
+            # format username:password
+            credential_list = self.provider.credentials.split(':')
+            if len(credential_list) != 2:
+                self.error("invalid credentials: {self.provider.credentials}")
+                self.status = "ERR_INVALID_CREDENTIALS"
+                return
+            username = credential_list[0][1:-1]
+            password = credential_list[1][1:-1]
+            auth = (username, password)
         else:
             self.status = "ERR_NO_CREDENTIALS"
             return

--- a/swirl/connectors/opensearch.py
+++ b/swirl/connectors/opensearch.py
@@ -86,14 +86,14 @@ class OpenSearch(Connector):
         client = None
         if self.provider.credentials:
             # extract auth
-            # format 'username','password'
-            credential_list = self.provider.credentials.split(',')
+            # format username:password
+            credential_list = self.provider.credentials.split(':')
             if len(credential_list) != 2:
                 self.error("invalid credentials: {self.provider.credentials}")
                 self.status = "ERR_INVALID_CREDENTIALS"
                 return
-            username = credential_list[0][1:-1]
-            password = credential_list[1][1:-1]
+            username = credential_list[0]
+            password = credential_list[1]
             auth = (username, password)
             # ca_certs_path = '/full/path/to/root-ca.pem' # Provide a CA bundle if you use intermediate CAs with your root CA.
             # Optional client certificates if you don't want to use HTTP basic authentication.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
X For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
Currently, elastic expects a string like `"(\"elastic\", \"elastic-password\")"` and turns it into a tuple, but the code is missing a step and so doesn't convert correctly.

This PR changes the elastic and opensearch credential format to `username:password` 
It needs testing!!


## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->
DS-1369 
https://github.com/swirlai/swirl-search/issues/1028

## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->
I have not tested the change

## Type of Change
<!-- Check all that apply to this PR. -->
- [ X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
