### PR TITLE
Add support for lists of dicts to SearchProvider endpoint

### DIFF
--- a/swirl/views.py
+++ b/swirl/views.py
@@ -285,12 +285,33 @@ class SearchProviderViewSet(viewsets.ModelViewSet):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         # by default, if the user is superuser, the searchprovider is shared
-        if self.request.user.is_superuser:
-           request.data['shared'] = 'true'
+        # if self.request.user.is_superuser:
+        #    request.data['shared'] = 'true'
+        # serializer = SearchProviderSerializer(data=request.data)
+        # serializer.is_valid(raise_exception=True)
+        # serializer.save(owner=self.request.user)
+        # return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-        serializer = SearchProviderSerializer(data=request.data)
+        is_list = isinstance(request.data, list)
+
+        # Modify data if the user is a superuser
+        if request.user.is_superuser:
+            if is_list:
+                # Apply changes to each item in the list
+                for item in request.data:
+                    item['shared'] = 'true'
+            else:
+                # Apply changes to the single object
+                request.data['shared'] = 'true'
+
+        # Use 'many' parameter based on whether request.data is a list or not
+        serializer = SearchProviderSerializer(data=request.data, many=is_list)
         serializer.is_valid(raise_exception=True)
-        serializer.save(owner=self.request.user)
+
+        # Save the serialized data
+        serializer.save(owner=request.user)
+
+        # Return response
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     ########################################


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
X For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
Add support for lists of dicts to SearchProvider endpoint
This change enable support for copying/pasting lists of JSON objects to the SearchProvider endpoint ONLY

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->
DS-1394

## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->
Tested copy/paste of lists and single dicts

## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
