### PR TITLE
Fix credential handling in elastic, opensearch

### DIFF
--- a/swirl/connectors/elastic.py
+++ b/swirl/connectors/elastic.py
@@ -102,9 +102,9 @@ class Elastic(VerifyCertsCommon):
                 es = Elasticsearch(basic_auth=tuple(auth),hosts=url,verify_certs=verify_certs,ca_certs=ca_certs)
             else:
                 if auth:
-                    es = Elasticsearch(basic_auth=tuple(auth),hosts=url,verify_certs=False)
+                    es = Elasticsearch(basic_auth=tuple(auth),hosts=url)
                 else:
-                    es = Elasticsearch(hosts=url,verify_certs=False)
+                    es = Elasticsearch(hosts=url)
 
         except NameError as err:
             self.error(f'NameError: {err}')

--- a/swirl/connectors/opensearch.py
+++ b/swirl/connectors/opensearch.py
@@ -85,9 +85,12 @@ class OpenSearch(VerifyCertsCommon):
 
         client = None
         if self.provider.credentials:
-            (username,password,verify_certs,ca_certs)=self.get_creds()
+            bearer = None
+            (username,password,verify_certs,ca_certs,bearer)=self.get_creds()
             if self.status in ("ERR_INVALID_CREDENTIALS", "ERR_NO_CREDENTIALS"):
                 return
+            if bearer:
+                self.warning(f"Warning: bearer token specified but not supported")
 
             auth = (username, password)
             # ca_certs_path = '/full/path/to/root-ca.pem' # Provide a CA bundle if you use intermediate CAs with your root CA.

--- a/swirl/connectors/verify_ssl_common.py
+++ b/swirl/connectors/verify_ssl_common.py
@@ -13,15 +13,10 @@ class VerifyCertsCommon(Connector):
         return s.strip().lower() in ['true', '1', 'yes', 'y']
 
     def log_invalid_credentials(self):
-        self.error("invalid credentials: {self.provider.credentials}")
+        self.error(f"invalid credentials: {self.provider.credentials}")
         self.status = "ERR_INVALID_CREDENTIALS"
 
     def get_creds(self, def_verify_certs=False):
-
-        if not self.provider.credentials:
-            self.error("no credentials: {self.provider.credentials}")
-            self.status = "ERR_NO_CREDENTIALS"
-            return
 
         cred_list = self.provider.credentials.split(',')
         uname=''
@@ -29,6 +24,10 @@ class VerifyCertsCommon(Connector):
         ca_certs = ''
         bearer = ''
         verify_certs=def_verify_certs
+
+        if not self.provider.credentials:
+            return uname, pw, verify_certs, ca_certs, bearer
+
         for cre in cred_list:
             if ':' in cre:
                 (uname,pw) = cre.split(':')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
This covers both elastic and opensearch
- Handle bearer token return from self.get_creds()
- Warn if bearer token is specified
 
Don't forget to switch url from https to http, if using local elastic or opensearch
Turn off elastic in config/elasticsearch.yml

For both connectors, may now specify cert config and/or username:password:

`verify_certs=[True|False],ca_certs=/path/to/cert/file.crt,username:password`
`username:password`

It may also be blank.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->
DS-1643

## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->
Elastic tested against Enron local
OpenSearch needs test

## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
