### PR TITLE
Fix error calling _log_n_store

### DIFF
--- a/swirl/processors/rag.py
+++ b/swirl/processors/rag.py
@@ -225,9 +225,9 @@ class RAGPostResultProcessor(PostResultProcessor):
                 temperature=0
             )
             model_response = completions_new.choices[0].message.content
-            self._log_n_store_warn(f'RAG: fetch_prompt_errors follow:')
+            logger.warning(f'RAG: fetch_prompt_errors follow:')
             for (k,v) in fetch_prompt_errors.items():
-                self._log_n_store_warn(f'RAG:\t url:{k} problem:{v}')
+                logger.warning(f'RAG:\t url:{k} problem:{v}')
         except Exception as err:
             if DO_MESSAGE_MOCK_ON_ERROR:
                 logger.error(f"error : {err} while creating CGPT response")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
X For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
Resolve DS-1651
ERROR 2024-02-10 13:11:28,198 rag error : RAGPostResultProcessor._log_n_store_warn() missing 2 required positional arguments: 'warn' and 'buffer' while creating CGPT response

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->
Tested RAG end-to-end

## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
