### PR TITLE
Fix request error "'NoneType' has no len()"

### DIFF
--- a/swirl/connectors/requests.py
+++ b/swirl/connectors/requests.py
@@ -318,8 +318,6 @@ class Requests(VerifyCertsCommon):
                 return
             # process the results
 
-            self.error("WTF!")
-
             if 'RESULTS' in mapped_response:
                 if not mapped_response['RESULTS']:
                     mapped_response['RESULTS'] = json_data

--- a/swirl/connectors/requests.py
+++ b/swirl/connectors/requests.py
@@ -303,15 +303,22 @@ class Requests(VerifyCertsCommon):
                 found = int(mapped_response['FOUND'])
                 self.found = found
             # check for 0 response
-            is_empty_list = 'RESULTS' in mapped_response and type(mapped_response['RESULTS']) == list and len(mapped_response['RESULTS']) == 0
+            is_empty_list = False
+            if 'RESULTS' in mapped_response:
+                is_empty_list = 'RESULTS' in mapped_response and type(mapped_response['RESULTS']) == list and len(mapped_response['RESULTS']) == 0
+            else:
+                is_empty_list = True
             if found == 0 or retrieved == 0 or is_empty_list:
                 # no results, not an error
                 self.message(f"Retrieved 0 of 0 results from: {self.provider.name}")
                 self.retrieved = 0
                 self.found = 0
                 self.status = 'READY'
+                self.response = []
                 return
             # process the results
+
+            self.error("WTF!")
 
             if 'RESULTS' in mapped_response:
                 if not mapped_response['RESULTS']:
@@ -358,6 +365,7 @@ class Requests(VerifyCertsCommon):
                             for match in matches:
                                 mapped_responses.append(match)
                         else:
+                            self.error("FAFKDLF")
                             self.error(f'control mapping RESULT matched {len(matches)}, expected {self.provider.results_per_query}')
                             return
                     else:
@@ -365,8 +373,11 @@ class Requests(VerifyCertsCommon):
                         pass
             else:
                 # no RESULT key specified
-                for res in mapped_response['RESULTS']:
-                    mapped_responses.append(res)
+                if mapped_response:
+                    for res in mapped_response['RESULTS']:
+                        mapped_responses.append(res)
+                else:
+                    self.error("NO RESULT KEY")
             # check retrieved
             if not mapped_responses:
                 self.error(f"no results extracted from response! found:{found}")
@@ -374,12 +385,18 @@ class Requests(VerifyCertsCommon):
                     found = retrieved = 0
                 # end if
             if retrieved == -1:
-                retrieved = len(mapped_responses)
-                self.retrieved = retrieved
+                if mapped_responses:
+                    retrieved = len(mapped_responses)
+                    self.retrieved = retrieved
+                else:
+                    self.error(f"NORESULTS")
             if found == -1:
                 # for now, assume the source delivered what it found
-                found = len(mapped_responses)
-                self.found = found
+                if mapped_responses:
+                    found = len(mapped_responses)
+                    self.found = found
+                else:
+                    self.error(f"NORESULTS")
             # check for 0 delivered results (different from above)
             if found == 0 or retrieved == 0:
                 # no results, not an error
@@ -394,7 +411,7 @@ class Requests(VerifyCertsCommon):
 
             start = start + 10 # get only as many pages as required to satisfy provider results_per_query setting, in increments of 10
 
-            time.sleep(1)
+            time.sleep(0.1)
 
         # end for
 

--- a/swirl/connectors/requests.py
+++ b/swirl/connectors/requests.py
@@ -363,7 +363,6 @@ class Requests(VerifyCertsCommon):
                             for match in matches:
                                 mapped_responses.append(match)
                         else:
-                            self.error("FAFKDLF")
                             self.error(f'control mapping RESULT matched {len(matches)}, expected {self.provider.results_per_query}')
                             return
                     else:

--- a/swirl/connectors/requestspost.py
+++ b/swirl/connectors/requestspost.py
@@ -74,4 +74,5 @@ class RequestsPost(Requests):
             post_json=query
 
         self._trace_message(f"post_json_str:{post_json_str} query:{query} post_json:{post_json}")
+        self.response = []
         return requests.post(url, params=params, json=post_json, **kwargs)


### PR DESCRIPTION
Set self.response = [] instead of None (from base class init) when no results DS-1652

<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
X For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
The error was because when found=0, self.response was not being set, and the normalize_response() method exploded

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->
DS-1652

## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->
Tested with PSEs

## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
