### PR TITLE
feat: Qdrant search provider

### DIFF
--- a/SearchProviders/preloaded.json
+++ b/SearchProviders/preloaded.json
@@ -1402,5 +1402,36 @@
             "Pinecone",
             "model:<your-embedding-model>"
         ]
+    },
+    {
+        "name": "QdrantDB",
+        "active": false,
+        "default": false,
+        "authenticator": "",
+        "connector": "QdrantDB",
+        "url": "qdrant_url-collection_name",
+        "query_template": "",
+        "query_template_json": {},
+        "post_query_template": {},
+        "http_request_headers": {},
+        "page_fetch_config_json": {},
+        "query_processors": [
+            "AdaptiveQueryProcessor"
+        ],
+        "query_mappings": "",
+        "result_grouping_field": "",
+        "result_processors": [
+            "MappingResultProcessor",
+            "AutomaticPayloadMapperResultProcessor",
+            "CosineRelevancyResultProcessor"
+        ],
+        "response_mappings": "",
+        "result_mappings": "",
+        "results_per_query": 10,
+        "credentials": "<qdrant-api-key>",
+        "eval_credentials": "",
+        "tags": [
+            "Qdrant"
+        ]
     }
 ]

--- a/SearchProviders/qdrant.json
+++ b/SearchProviders/qdrant.json
@@ -1,0 +1,31 @@
+{
+    "name": "QdrantDB",
+    "active": false,
+    "default": false,
+    "authenticator": "",
+    "connector": "QdrantDB",
+    "url": "qdrant_url-collection_name",
+    "query_template": "",
+    "query_template_json": {},
+    "post_query_template": {},
+    "http_request_headers": {},
+    "page_fetch_config_json": {},
+    "query_processors": [
+        "AdaptiveQueryProcessor"
+    ],
+    "query_mappings": "",
+    "result_grouping_field": "",
+    "result_processors": [
+        "MappingResultProcessor",
+        "AutomaticPayloadMapperResultProcessor",
+        "CosineRelevancyResultProcessor"
+    ],
+    "response_mappings": "",
+    "result_mappings": "",
+    "results_per_query": 10,
+    "credentials": "<qdrant-api-key>",
+    "eval_credentials": "",
+    "tags": [
+        "Qdrant"
+    ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,3 +155,4 @@ weasel==0.3.4
 whitenoise==6.6.0
 xmltodict==0.13.0
 zope.interface==6.4.post0
+qdrant-client==1.10.0

--- a/swirl/connectors/__init__.py
+++ b/swirl/connectors/__init__.py
@@ -8,6 +8,7 @@ from swirl.connectors.requestspost import RequestsPost
 from swirl.connectors.sqlite3 import Sqlite3
 from swirl.connectors.elastic import Elastic
 from swirl.connectors.opensearch import OpenSearch
+from swirl.connectors.qdrant import QdrantDB
 from swirl.connectors.bigquery import BigQuery
 from swirl.connectors.gen_ai import GenAI
 from swirl.connectors.microsoft_graph import M365OutlookMessages

--- a/swirl/connectors/gen_ai.py
+++ b/swirl/connectors/gen_ai.py
@@ -85,10 +85,11 @@ class GenAI(Connector):
         message = completions.choices[0].message.content
         self.found = 1
         self.retrieved = 1
+        msg = message.replace("\n\n", "")
         self.response = [
                 {
                 'title': self.query_string_to_provider,
-                'body': f'{message.replace("\n\n", "")}',
+                'body': f'{msg}',
                 'author': f'{llm.get_provider().model}',
                 'date_published': str(datetime.now()),
                 'model': f'{llm.get_provider().model}'

--- a/swirl/connectors/qdrant.py
+++ b/swirl/connectors/qdrant.py
@@ -1,0 +1,71 @@
+"""
+@author:     Anush008
+@contact:    anush.shetty@qdrant.com
+"""
+
+from sys import path
+from os import environ
+
+import django
+
+from swirl.utils import swirl_setdir
+
+path.append(swirl_setdir())
+environ.setdefault("DJANGO_SETTINGS_MODULE", "swirl_server.settings")
+django.setup()
+
+from celery.utils.log import get_task_logger
+
+logger = get_task_logger(__name__)
+
+from swirl.connectors.vdb_connector import VectorDBConnector
+from qdrant_client import QdrantClient
+
+
+class QdrantDB(VectorDBConnector):
+    type = "QdrantDB"
+
+    def execute_search(self, session=None):
+        logger.debug(f"{self}: execute_search()")
+
+        api_key = self.provider.credentials
+        qdrant_url, collection_name = self.provider.url.split("-", maxsplit=1)
+
+        if not self.vector_to_provider:
+            self.status = "ERR"
+            self.error(f"No vector for query: {self.query_string_to_provider}")
+            return
+
+        try:
+            client = QdrantClient(url=qdrant_url, api_key=api_key)
+            response = client.search(
+                collection_name,
+                query_vector=self.vector_to_provider,
+                limit=self.provider.results_per_query,
+                with_payload=True,
+                with_vectors=False,
+            )
+        except Exception as err:
+            self.error(f"{err} connecting to {self.type}")
+            self.status = "ERR"
+            return
+
+        result_list = []
+        if response:
+            for point in response:
+                item = point.payload
+                item["id"] = str(point.id)
+                item["similarity"] = point.score
+                result_list.append(item)
+
+        else:
+            self.message(f"Retrieved 0 of 0 results from: {self.provider.name}")
+            self.status = "READY"
+            self.found = 0
+            self.retrieved = 0
+            return
+
+        self.found = len(response)
+        self.retrieved = len(result_list)
+        self.response = result_list
+        return

--- a/swirl/models.py
+++ b/swirl/models.py
@@ -73,6 +73,7 @@ class SearchProvider(models.Model):
         ('RequestsPost', 'HTTP/POST returning JSON'),
         ('Elastic', 'Elasticsearch Query String'),
         ('OpenSearch', 'OpenSearch Query String'),
+        ('QdrantDB', 'QdrantDB'),
         # Uncomment the line below to enable PostgreSQL
         # ('PostgreSQL', 'PostgreSQL'),
         ('BigQuery', 'Google BigQuery'),
@@ -85,7 +86,7 @@ class SearchProvider(models.Model):
         ('MongoDB', 'MongoDB'),
         ('Oracle','Oracle'),
         ('Snowflake','Snowflake'),
-        ('PineconeDB','PineconeDB')
+        ('PineconeDB','PineconeDB'),
     ]
     connector = models.CharField(max_length=200, default='RequestsGet', choices=CONNECTOR_CHOICES)
     url = models.CharField(max_length=2048, default=str, blank=True)


### PR DESCRIPTION
## Description
This PR adds a search provider implementation using Qdrant - https://qdrant.tech./.

I noticed Qdrant is mentioned in the docs at https://github.com/swirlai/swirl-search/blob/main/docs/index.md#what-systems-can-swirl-ai-connect-integrate-with

However, the implementation was not present.


## Notes

- The URL is to be passed as
 `QDRANT_URL-COLLECTION-NAME`

Eg: `http://localhost:6333-my_collection`

- To start Qdrant 

```
docker run -p 6333:6333 qdrant/qdrant
```

- To create a collection, refer to https://qdrant.tech/documentation/concepts/collections/#create-a-collection.

- To add points, refer to https://qdrant.tech/documentation/concepts/points/#upload-points

- There'll also be a dashboard at http://localhost:6333/dashboard