### PR TITLE
Fix 'k' typo

### DIFF
--- a/swirl/processors/mapping.py
+++ b/swirl/processors/mapping.py
@@ -423,16 +423,16 @@ class AutomaticPayloadMapperResultProcessor(ResultProcessor):
                 if k == 'payload':
                     continue
                 if k in item['payload']:
-                    if not item['k']:
+                    if not item[k]:
                         if type(item['payload'][k]) == str:
-                            item['k'] = item['payload'][k]
+                            item[k] = item['payload'][k]
                             automapped_fields.append(k)
                             self.warning("copying payload field {k}")
                 for f in field_scan_list:
                     if f.startswith(k) or f.endswith(k):
-                        if not item['k']:
+                        if not item[k]:
                             if type(item['payload'][f]) == str:
-                                item['k'] = item['payload'][f]
+                                item[k] = item['payload'][f]
                                 automapped_fields.append(f)
                                 self.warning("copying payload field {f}")
 


### PR DESCRIPTION
Fix DS-2447

<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

Note: by agreement going directly to `main` with this

## Description
<!--- Describe in detail the work in this PR. -->
In the AutoMapper, there is a typo 'k' in a few branches
This resolves it

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->
DS-2447

## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->
Tested w/qdrant
Unlikely to make things worse

## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
