### PR TITLE
DS-2758 Reduce trigger to just main

### DIFF
--- a/.github/workflows/urls-checker.yml
+++ b/.github/workflows/urls-checker.yml
@@ -37,7 +37,7 @@ jobs:
           verbose: true
           timeout: 5
           retry_count: 3
-          exclude_patterns: localhost,api,apis,rss,etc,xx,googleapis,hostname,snowflake,graph.microsoft.com,login.microsoftonline.com,my-host.com,azure.com,github.com
+          exclude_patterns: localhost,api,apis,rss,etc,xx,googleapis,hostname,snowflake,graph.microsoft.com,login.microsoftonline.com,my-host.com,azure.com,github.com,platform.openai.com/docs/guides/chat-completions/getting-started
           exclude_files: Swirl.postman_collection.json,docs/googlec95caf0bd4a8c5df.html,docs/Gemfile,docs/Gemfile.lock,docs/_config.yml,tests/,SearchProviders/,DevUtils/
           save: ${{ env.URLCHECK_RESULTS }}
 

--- a/.github/workflows/urls-checker.yml
+++ b/.github/workflows/urls-checker.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - "main"
-      - "develop"
     paths:
       - "docs/**"
       - "README.md"

--- a/docs/DOCKER_BUILD.md
+++ b/docs/DOCKER_BUILD.md
@@ -148,3 +148,4 @@ In the SearchProvider configuration, replace localhost with the hostname:
 ```
 "url": "http://AgentCooper.local:8983/solr/{collection}/select?wt=json",
 ```
+

--- a/docs/DOCKER_BUILD.md
+++ b/docs/DOCKER_BUILD.md
@@ -148,4 +148,3 @@ In the SearchProvider configuration, replace localhost with the hostname:
 ```
 "url": "http://AgentCooper.local:8983/solr/{collection}/select?wt=json",
 ```
-


### PR DESCRIPTION


## Description
- Reduce the triggering events to main PRs only.  Develop doesn't have docs
- added `https://platform.openai.com/docs/guides/chat-completions/getting-started` to exclusions as it's a false positive.  The link is fine

## Related Issue(s)
Internal issue [DS-2758](https://swirl.youtrack.cloud/issue/DS-2758)



## Testing and Validation
- Made newline only change to a doc and saw workflow triggered
- Workflow found false positive issue:

> 🤔 Uh oh... The following urls did not pass:
> /github/workspace/docs/AI-Co-Pilot.md:
>      ❌️ https://platform.openai.com/docs/guides/chat-completions/getting-started
> ##[debug]Docker Action run completed with exit code 1
> ##[debug]Finishing: URLs Checker
> 

## Type of Change
- [ ] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [x] Documentation (change to product documentation or README.md only)
