### PR TITLE
DS-1385 update doc to match rag_timeout now specified in seconds

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -157,7 +157,9 @@ The `qs=` parameter can also be used with the [providers](#specify-searchprovide
 
 RAG processing is available through a single API call using `qs=`, e.g. `?qs=metasearch&rag=true`.
 
-The default AI Summary timeout value can be overridden with a URL parameter in the Galaxy UI. For example: `http://localhost:8000/galaxy/?q=gig%20economics&rag=true&rag_timeout=90000`
+The default AI Summary timeout value can be overridden with a URL parameter in the Galaxy UI. For example: `http://localhost:8000/galaxy/?q=gig%20economics&rag=true&rag_timeout=90`
+{: .highlight }
+Starting with SWIRL 3.7.0, we specify `rag_timeout`in seconds
 
 Note that `&page=` is NOT supported with `qs=`; to access the second page of results use the `next_page` property from the `info.results` structure.
 

--- a/docs/RAG-Guide.md
+++ b/docs/RAG-Guide.md
@@ -71,7 +71,9 @@ SWIRL AI Connect Community Edition supports RAG only against OpenAI and Azure/Op
 
 Adjust the `timeout` value if necessary. Change the `User-Agent` string as needed, and/or authorize it to fetch pages from internal applications.
 
-You can also override the default timeout value with a URL parameter in the Galaxy UI. For example: `http://localhost:8000/galaxy/?q=gig%20economics&rag=true&rag_timeout=90000`
+You can also override the default timeout value with a URL parameter in the Galaxy UI. For example: `http://localhost:8000/galaxy/?q=gig%20economics&rag=true&rag_timeout=90`
+{: .highlight }
+Starting with SWIRL 3.7.0, we specify `rag_timeout`in seconds
 
 * Restart SWIRL:
 


### PR DESCRIPTION

## Description
Update doc given as of SWIRL 3.7.0, [DS-1385](https://swirl.youtrack.cloud/issue/DS-1385) issue changed `rag_timeout` from milliseconds to seconds

## Related Issue(s)
[DS-1385](https://swirl.youtrack.cloud/issue/DS-1385)

## Testing and Validation
Local doc review


## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [x] Documentation (change to product documentation or README.md only)
