### PR TITLE
DS-2818 Swirl-Search Repo PR require spell-check to pass

### DIFF
--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -33,10 +33,3 @@ jobs:
       with:
         config: ./.github/workflows/typos.toml
         write_changes: true  # Writes changes on the Action's local checkout
-
-    - name: Capture Git Diff
-      if: always()
-      run: |
-        git diff > diff_output.txt
-        echo "## Git Diff Output" >> $GITHUB_STEP_SUMMARY
-        cat diff_output.txt >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -35,6 +35,7 @@ jobs:
         write_changes: true  # Writes changes on the Action's local checkout
 
     - name: Capture Git Diff
+      if: always()
       run: |
         git diff > diff_output.txt
         echo "## Git Diff Output" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -2,7 +2,24 @@ name: Check Spelling
 
 # Only allow manual run of this workflow from the Actions tab
 on:
+  pull_request:
+    # Run for all PRs to develop - means PR cannot merge until unit tests pass
+    branches:
+      - develop
+      - main
+    # Skip non-code changes
+    paths-ignore:
+      - '.github/**'
+      - 'integrations/**'
+      - 'swirl-infra/**'
+      - 'db.sqlite3.dist'
   workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  pull-requests: write
 
 jobs:
   build:
@@ -16,3 +33,9 @@ jobs:
       with:
         config: ./.github/workflows/typos.toml
         write_changes: true  # Writes changes on the Action's local checkout
+
+    - name: Capture Git Diff
+      run: |
+        git diff > diff_output.txt
+        echo "## Git Diff Output" >> $GITHUB_STEP_SUMMARY
+        cat diff_output.txt >> $GITHUB_STEP_SUMMARY

--- a/swirl/connectors/verify_ssl_common.py
+++ b/swirl/connectors/verify_ssl_common.py
@@ -34,7 +34,7 @@ class VerifyCertsCommon(Connector):
 
         for cre in cred_list:
             if cre.startswith('bearer='):
-                # handle this speacial becauase tokens have '=' sign in them
+                # handle this special becauase tokens have '=' sign in them
                 bearer = cre[len('bearer='):]
                 if not bearer:
                     self.log_invalid_credentials()


### PR DESCRIPTION
Spell checker should run on code merging to develop or main

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
This impacts messages within source and within doc so it should execute upon main and develop targetted PRs

## Related Issue(s)
DS-2818

## Testing and Validation
- [ran manually](https://github.com/swirlai/swirl-search/actions/runs/11016405079) has error
```[build: swirl/connectors/verify_ssl_common.py#L37](https://github.com/swirlai/swirl-search/commit/e95210b8c66ba12514487ec5a074a6d8adff66bd#annotation_26645167826)
"speacial" should be "special" or "spacial".
```
- Fixed above and in this PR [action ran automatically](https://github.com/swirlai/swirl-search/actions/runs/11016604328) and passed

## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [x] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
