### PR TITLE
update base Python image to 3.12.8

### DIFF
--- a/.github/workflows/db-dist.yml
+++ b/.github/workflows/db-dist.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.6'
+          python-version: '3.12.8'
           cache: 'pip'
       - name: Install Swirl (with a timeout)
         run: ./install.sh

--- a/.github/workflows/qa-suite.yml
+++ b/.github/workflows/qa-suite.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.6'
+          python-version: '3.12.8'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -25,7 +25,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.6'
+            python-version: '3.12.8'
             cache: 'pip'
         - name: Install Swirl
           run: ./install.sh
@@ -56,7 +56,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.6'
+            python-version: '3.12.8'
             cache: 'pip'
         - name: Install Swirl (with a timeout)
           run: ./install.sh
@@ -125,7 +125,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.6'
+            python-version: '3.12.8'
             cache: 'pip'
         - name: Install Swirl
           run: ./install.sh

--- a/.github/workflows/testing-wip.yml
+++ b/.github/workflows/testing-wip.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.6'
+          python-version: '3.12.8'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.6'
+          python-version: '3.12.8'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.6-slim-bookworm
+FROM python:3.12.8-slim-bookworm
 
 # Update, upgrade and install packages in a single RUN to reduce layers
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->


## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->
DS-3574: Update base Python image used in Dockerfiles and GitHub Actions to 3.12.8
MS Presidio now supports Python 3.12 series fully, FYI.

## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [x] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
