### PR TITLE
update Python base image to v3.12.10; unpin Celery and Django in …

### DIFF
--- a/.github/workflows/db-dist.yml
+++ b/.github/workflows/db-dist.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.9'
+          python-version: '3.12.10'
           cache: 'pip'
       - name: Install Swirl (with a timeout)
         run: ./install.sh

--- a/.github/workflows/qa-suite.yml
+++ b/.github/workflows/qa-suite.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.9'
+          python-version: '3.12.10'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -25,7 +25,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.9'
+            python-version: '3.12.10'
             cache: 'pip'
         - name: Install Swirl
           run: ./install.sh
@@ -56,7 +56,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.9'
+            python-version: '3.12.10'
             cache: 'pip'
         - name: Install Swirl (with a timeout)
           run: ./install.sh
@@ -125,7 +125,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.9'
+            python-version: '3.12.10'
             cache: 'pip'
         - name: Install Swirl
           run: ./install.sh

--- a/.github/workflows/testing-wip.yml
+++ b/.github/workflows/testing-wip.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.9'
+          python-version: '3.12.10'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.9'
+          python-version: '3.12.10'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.9-slim-bookworm
+FROM python:3.12.10-slim-bookworm
 
 # Update, upgrade and install packages in a single RUN to reduce layers
 RUN apt-get update && apt-get install -y \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 requests
-Django>=5.1
+Django
 django_restframework
 django-celery-beat
-Celery>=5.5.0rc5
+Celery
 pika
-elasticsearch
+elasticsearch<9.0.0
 jsonpath-ng
 pyyaml
 whitenoise


### PR DESCRIPTION
…requirements; pin Elasticsearch to not use the new v9.0.0

DS-4020