### PR TITLE
[DS 4002] Improve ability for users to configure GenAI model for RAG

### DIFF
--- a/swirl/openai/openai.py
+++ b/swirl/openai/openai.py
@@ -59,7 +59,8 @@ class OpenAIClient:
                 ai_client = OpenAI(api_key=key)
             elif provider == "AZUREAI":
                 from openai import AzureOpenAI
-                ai_client = AzureOpenAI(api_key=key, azure_endpoint=self._azure_endpoint, api_version="2023-10-01-preview")
+                self._azure_api_version = getattr(settings, "AZURE_API_VERSION", None)
+                ai_client = AzureOpenAI(api_key=key, azure_endpoint=self._azure_endpoint, api_version=self._azure_api_version)
             else:
                 raise NotImplementedError(f"Unknown AI provider {provider}. Client initialization not supported.")
         except Exception as err:

--- a/swirl_server/settings.py
+++ b/swirl_server/settings.py
@@ -295,6 +295,7 @@ OPENAI_API_KEY = env.get_value('OPENAI_API_KEY', default='')
 AZURE_OPENAI_KEY = env.get_value('AZURE_OPENAI_KEY', default='')
 AZURE_OPENAI_ENDPOINT = env.get_value('AZURE_OPENAI_ENDPOINT', default='')
 AZURE_MODEL = env.get_value('AZURE_MODEL', default='')
+AZURE_API_VERSION = os.getenv("AZURE_API_VERSION", default='') 
 
 # Defines for RAG ChatGPT models
 CGPT_MODEL_3 = "gpt-3.5-turbo"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Description
This PR adds support for configuring the AZURE_API_VERSION via the .env file and settings.py, replacing the previously hardcoded value in openai.py.

Additionally, it ensures that the system can switch between Azure OpenAI and OpenAI clients purely through environment variables, without requiring code modifications. This helps support more flexible deployment and testing of various model versions and providers.

## Testing and Validation
- Added `AZURE_API_VERSION` to `.env` and verified that the value is read via `settings.py`.
- Modified `openai.py` to use `settings.AZURE_API_VERSION` dynamically.
- Validated that Azure OpenAI client is correctly initialized with the configured version.
- Unset all Azure-related variables and tested with `OPENAI_API_KEY` and `SWIRL_RAG_MODEL=gpt-4o` to confirm OpenAI client works as expected.


## Type of Change
<!-- Check all that apply to this PR. -->
[ x ] Bug fix or other non-breaking change that addresses an issue
[ x ] New Feature / Enhancement (non-breaking change that add or improves functionality)
