### PR TITLE
[DS-4002] Temporary fix for gpt-4.1 encoding model

### DIFF
--- a/swirl/openai/openai.py
+++ b/swirl/openai/openai.py
@@ -33,7 +33,7 @@ class OpenAIClient:
         self._swirl_q_model   = getattr(settings,"SWIRL_QUERY_MODEL", None)
         self._swirl_rag_model = getattr(settings,'SWIRL_RAG_MODEL',None)
 
-        logger.info(f'>>>>>> cons config : {self._openapi_key} {self._azure_model}'
+        logger.debug(f'cons config : {self._openapi_key} {self._azure_model}'
                     f'{self._azureapi_key} {self._azure_endpoint} {self._swirl_rw_model} {self._swirl_q_model} {self._swirl_rag_model}')
 
         self._api_key = None


### PR DESCRIPTION
[DS-4002] Temporary fix for gpt-4.1 encoding model

## Description

We encountered a logging error when setting SWIRL_RAG_MODEL=gpt-4.1, caused by the tiktoken.get_encoding function.

As outlined in this GitHub issue (https://github.com/openai/tiktoken/issues/395), the problem is still unresolved. However, there is an open pull request addressing it: https://github.com/openai/tiktoken/pull/396/files.

As a temporary workaround, we're using the same encoding as gpt-4o. Once the library is updated with a proper fix, we can safely remove this workaround.


## Type of Change
<!-- Check all that apply to this PR. -->
- [x] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)