### PR TITLE
Update base Python image to 3.12.11 on Community develop

### DIFF
--- a/.github/workflows/db-dist.yml
+++ b/.github/workflows/db-dist.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.10'
+          python-version: '3.12.11'
           cache: 'pip'
       - name: Install Swirl (with a timeout)
         run: ./install.sh

--- a/.github/workflows/qa-suite.yml
+++ b/.github/workflows/qa-suite.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.10'
+          python-version: '3.12.11'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -25,7 +25,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.10'
+            python-version: '3.12.11'
             cache: 'pip'
         - name: Install Swirl
           run: ./install.sh
@@ -56,7 +56,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.10'
+            python-version: '3.12.11'
             cache: 'pip'
         - name: Install Swirl (with a timeout)
           run: ./install.sh
@@ -125,7 +125,7 @@ jobs:
         - name: Set Up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12.10'
+            python-version: '3.12.11'
             cache: 'pip'
         - name: Install Swirl
           run: ./install.sh

--- a/.github/workflows/testing-wip.yml
+++ b/.github/workflows/testing-wip.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.10'
+          python-version: '3.12.11'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.10'
+          python-version: '3.12.11'
           cache: 'pip'
       - name: Install Swirl
         run: ./install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.10-slim-bookworm
+FROM python:3.12.11-slim-bookworm
 
 # Update, upgrade and install packages in a single RUN to reduce layers
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
DS-4336 (goofed mu branch name...sigh)

Local testing detailed in the ticket:  Unit tests, QA Suite, and manual testing all looked good locally running under a fresh build and new `venv` with Python 3.12.11.

Running a QA Suite workflow on this branch as well:  https://github.com/swirlai/swirl-search/actions/runs/16036144455
... and it passed, woot!
