### PR TITLE
add the --no-capture option to the Behave command in testing-wip.yml

### DIFF
--- a/.github/workflows/testing-wip.yml
+++ b/.github/workflows/testing-wip.yml
@@ -113,7 +113,7 @@ jobs:
           echo "========"
           cat .env.qa
           echo "========"
-          docker run --net=host --env-file .env.qa -t swirlai/swirl-search-qa:${{ github.event.inputs.qa_image }} sh -c "behave --tags=${{ github.event.inputs.behave_tags }}"
+          docker run --net=host --env-file .env.qa -t swirlai/swirl-search-qa:${{ github.event.inputs.qa_image }} sh -c "behave --no-capture --tags=${{ github.event.inputs.behave_tags }}"
       - name: Upload Log Files
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Part of working our some QA automated test issues in DS-4195; this one workflow (used for testing the tests) should run Behave with the `--no-capture` option so we get more detailed output in the test runs.
