### PR TITLE
skip the Docker repo description update step in the pipeline and plai…

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,12 +22,12 @@ jobs:
               TAG_NAME=$([ "$BRANCH_NAME" = "main" ] && echo "latest" || echo "$BRANCH_NAME")
               docker buildx use devBuilder || docker buildx create --name devBuilder --use
               docker buildx build -t swirlai/swirl-search:$TAG_NAME --platform linux/amd64,linux/arm64 --push .
-          - name: Update the Docker Repo Description
-            uses: peter-evans/dockerhub-description@v4
-            with:
-              username: ${{ secrets.SBS_DOCKER_USER }}
-              password: ${{ secrets.SBS_DOCKER_PAT }}
-              repository: swirlai/swirl-search
+          # - name: Update the Docker Repo Description
+          #   uses: peter-evans/dockerhub-description@v4
+          #   with:
+          #     username: ${{ secrets.SBS_DOCKER_USER }}
+          #     password: ${{ secrets.SBS_DOCKER_PAT }}
+          #     repository: swirlai/swirl-search
           - name: Upload Log Files
             if: always()
             uses: actions/upload-artifact@v4

--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -218,12 +218,12 @@ jobs:
             TAG_NAME=$([ "$BRANCH_NAME" = "main" ] && echo "latest" || echo "$BRANCH_NAME")
             docker buildx use devBuilder || docker buildx create --name devBuilder --use
             docker buildx build -t swirlai/swirl-search:$TAG_NAME --platform linux/amd64,linux/arm64 --push .
-        - name: Update the Docker Repo Description
-          uses: peter-evans/dockerhub-description@v4
-          with:
-            username: ${{ secrets.SBS_DOCKER_USER }}
-            password: ${{ secrets.SBS_DOCKER_PAT }}
-            repository: swirlai/swirl-search
+        # - name: Update the Docker Repo Description
+        #   uses: peter-evans/dockerhub-description@v4
+        #   with:
+        #     username: ${{ secrets.SBS_DOCKER_USER }}
+        #     password: ${{ secrets.SBS_DOCKER_PAT }}
+        #     repository: swirlai/swirl-search
         - name: Upload Log Files
           if: always()
           uses: actions/upload-artifact@v4


### PR DESCRIPTION
DS-4374

Skip the Docker repo description update step in the test and build pipeline workflow and the regular docker image build workflow for now (on `develop`); due to the on-going issue at Docker Hub.