### PR TITLE
[DS-4322] Added TimeoutMiddleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ drf-spectacular
 qdrant-client==1.10.0
 presidio-analyzer
 presidio-anonymizer
+func_timeout

--- a/swirl_server/settings.py
+++ b/swirl_server/settings.py
@@ -96,6 +96,7 @@ MIDDLEWARE = [
     'swirl.middleware.TokenMiddleware',
     'swirl.middleware.SpyglassAuthenticatorsMiddleware',
     'swirl.middleware.SwaggerMiddleware',
+    'swirl.middleware.TimeoutMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
# [DS-4322](https://swirl.youtrack.cloud/agiles/141-5/current?issue=DS-4322) Added TimeoutMiddleware

## Description
The rag_timeout parameter was being ignored, as there is no middleware responsible for handling it. Added TimeoutMiddleware.

## Related Issue(s)
DS-4322

## Testing and Validation
Built locally

## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [x] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
