### PR TITLE
DS-5598: also guard env.int() against empty-string docker-compose substitution

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,13 +25,13 @@ services:
              python swirl.py start celery-worker celery-beats &&
              daphne -b 0.0.0.0 -p 8000 swirl_server.asgi:application'
     environment: # Environment variables section
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - AZURE_OPENAI_KEY=${AZURE_OPENAI_KEY}
-      - AZURE_OPENAI_ENDPOINT=${AZURE_OPENAI_ENDPOINT}
-      - AZURE_MODEL=${AZURE_MODEL}
-      - AZURE_API_VERSION=${AZURE_API_VERSION}
-      - SWIRL_RAG_MODEL=${SWIRL_RAG_MODEL}
-      - SWIRL_REWRITE_MODEL=${SWIRL_REWRITE_MODEL}
-      - SWIRL_QUERY_MODEL=${SWIRL_QUERY_MODEL}
-      - SWIRL_RAG_TOK_MAX=${SWIRL_RAG_TOK_MAX}
-      - SWIRL_RAG_MAX_TO_CONSIDER=${SWIRL_RAG_MAX_TO_CONSIDER}
+      - OPENAI_API_KEY
+      - AZURE_OPENAI_KEY
+      - AZURE_OPENAI_ENDPOINT
+      - AZURE_MODEL
+      - AZURE_API_VERSION
+      - SWIRL_RAG_MODEL
+      - SWIRL_REWRITE_MODEL
+      - SWIRL_QUERY_MODEL
+      - SWIRL_RAG_TOK_MAX=${SWIRL_RAG_TOK_MAX:-4000}
+      - SWIRL_RAG_MAX_TO_CONSIDER=${SWIRL_RAG_MAX_TO_CONSIDER:-10}

--- a/swirl_server/settings.py
+++ b/swirl_server/settings.py
@@ -20,6 +20,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 env = environ.Env()
 environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 
+def _env_int(name, default):
+    """Like env.int() but treats an empty-string value (e.g. from docker-compose
+    shell-substitution when the host var is unset) as absent, falling back to default."""
+    val = os.environ.get(name, '').strip()
+    return int(val) if val else default
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
@@ -268,7 +274,7 @@ SWIRL_DEFAULT_QUERY_LANGUAGE = 'english'
 # Decrease it for faster responses at the cost of missing slower providers.
 # Can also be set via the SWIRL_TIMEOUT environment variable.
 SWIRL_TIMEOUT_DEFAULT = 10
-SWIRL_TIMEOUT = env.int('SWIRL_TIMEOUT',default=SWIRL_TIMEOUT_DEFAULT)
+SWIRL_TIMEOUT = _env_int('SWIRL_TIMEOUT', default=SWIRL_TIMEOUT_DEFAULT)
 SWIRL_SUBSCRIBE_WAIT = 20
 SWIRL_DEDUPE_FIELD = 'url'
 SWIRL_DEDUPE_SIMILARITY_MINIMUM = 0.95
@@ -328,28 +334,28 @@ SWIRL_QUERY_MODEL = env.get_value('SWIRL_QUERY_MODEL', default='')
 SWIRL_AI_DROP_UNSUP_PARAMS = env.bool('SWIRL_AI_DROP_UNSUP_PARAMS', default=True)
 SWIRL_LITELLM_DEBUG = env.bool('SWIRL_LITELLM_DEBUG', default=False)
 SWIRL_LITELLM_MODIFY_PARAMS = env.bool('SWIRL_LITELLM_MODIFY_PARAMS', default=True)
-SWIRL_LITELLM_TIMEOUT = env.int('SWIRL_LITELLM_TIMEOUT', default=90)
+SWIRL_LITELLM_TIMEOUT = _env_int('SWIRL_LITELLM_TIMEOUT', default=90)
 
 # LiteLLM response cache (off by default)
 # Set SWIRL_LITELLM_CACHE_ENABLED=True to enable. For multi-worker installs
 # set SWIRL_LITELLM_CACHE_TYPE=redis and supply SWIRL_LITELLM_CACHE_REDIS_HOST.
 SWIRL_LITELLM_CACHE_ENABLED = env.bool('SWIRL_LITELLM_CACHE_ENABLED', default=False)
 SWIRL_LITELLM_CACHE_TYPE = env.get_value('SWIRL_LITELLM_CACHE_TYPE', default='local')  # 'local' | 'redis'
-SWIRL_LITELLM_CACHE_TTL = env.int('SWIRL_LITELLM_CACHE_TTL', default=300)
+SWIRL_LITELLM_CACHE_TTL = _env_int('SWIRL_LITELLM_CACHE_TTL', default=300)
 SWIRL_LITELLM_CACHE_REDIS_HOST = env.get_value('SWIRL_LITELLM_CACHE_REDIS_HOST', default='')
-SWIRL_LITELLM_CACHE_REDIS_PORT = env.int('SWIRL_LITELLM_CACHE_REDIS_PORT', default=6379)
+SWIRL_LITELLM_CACHE_REDIS_PORT = _env_int('SWIRL_LITELLM_CACHE_REDIS_PORT', default=6379)
 SWIRL_LITELLM_CACHE_REDIS_PASSWORD = env.get_value('SWIRL_LITELLM_CACHE_REDIS_PASSWORD', default='')
 
 # Embedding / similarity
 SWIRL_USE_FAST_SIMILARITY = env.bool('SWIRL_USE_FAST_SIMILARITY', default=True)
 SWIRL_USE_UNIT_EMBEDDINGS = env.bool('SWIRL_USE_UNIT_EMBEDDINGS', default=True)
-SWIRL_RAG_TOK_DEFAULT = env.int('SWIRL_RAG_TOK_DEFAULT', default=4000)
-SWIRL_ST_BATCH_SIZE = env.int('SWIRL_ST_BATCH_SIZE', default=32)
-SWIRL_OLLAMA_EMBED_BATCH_SIZE = env.int('SWIRL_OLLAMA_EMBED_BATCH_SIZE', default=128)
+SWIRL_RAG_TOK_DEFAULT = _env_int('SWIRL_RAG_TOK_DEFAULT', default=4000)
+SWIRL_ST_BATCH_SIZE = _env_int('SWIRL_ST_BATCH_SIZE', default=32)
+SWIRL_OLLAMA_EMBED_BATCH_SIZE = _env_int('SWIRL_OLLAMA_EMBED_BATCH_SIZE', default=128)
 
 # RAG token and results budgets
-SWIRL_RAG_TOK_MAX = env.int('SWIRL_RAG_TOK_MAX', default=4000)   # low default for backward compatibility only
-SWIRL_RAG_MAX_TO_CONSIDER = env.int('SWIRL_RAG_MAX_TO_CONSIDER', default=10)
+SWIRL_RAG_TOK_MAX = _env_int('SWIRL_RAG_TOK_MAX', default=4000)   # low default for backward compatibility only
+SWIRL_RAG_MAX_TO_CONSIDER = _env_int('SWIRL_RAG_MAX_TO_CONSIDER', default=10)
 
 SWIRL_ALWAYS_FALL_BACK_TO_SUMMARY_DEF=True
 SWIRL_ALWAYS_FALL_BACK_TO_SUMMARY=env.bool('SWIRL_ALWAYS_FALL_BACK_TO_SUMMARY',default=SWIRL_ALWAYS_FALL_BACK_TO_SUMMARY_DEF)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
X For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
fix: guard env.int() against empty-string docker-compose substitution

- settings.py: replace all env.int() calls with _env_int() helper that
  treats empty-string values as absent, falling back to the default
- docker-compose.yaml: use \${VAR:-default} for integer vars so the
  container always receives a valid integer regardless of host env state;
  string vars use passthrough syntax (no = suffix)

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->

## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [X] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
