### PR TITLE
DS-5598: RAG citations, plain-text response, MS token header fast-path, instrumentation

### DIFF
--- a/swirl/processors/rag.py
+++ b/swirl/processors/rag.py
@@ -167,6 +167,11 @@ class RAGPostResultProcessor(PostResultProcessor):
         # Use module-level, settings-driven config
         chosen_rag = sorted_rag[:RAG_MAX_TO_CONSIDER]
 
+        logger.info(f"RAG: considering {len(chosen_rag)} of {len(sorted_rag)} results for query '{user_query}'")
+        for i, item in enumerate(chosen_rag):
+            body_len = len((item.get('body') or '').split())
+            logger.info(f"RAG candidate [{i+1}] provider={item.get('searchprovider','?')} score={item.get('swirl_score','?')} body_words={body_len} url={item.get('url','')[:80]}")
+
         max_tokens = RAG_MAX_TOKENS
         fallback_text = ""
         fallback_tokens = 0
@@ -175,6 +180,7 @@ class RAGPostResultProcessor(PostResultProcessor):
             max_tokens=max_tokens,
             model=self.client.get_encoding_model()
         )
+        logger.info(f"RAG: token budget={max_tokens} model={self.client.get_encoding_model()}")
 
         fetch_prompt_errors = {}
         from swirl.tasks import page_fetcher_task
@@ -195,8 +201,16 @@ class RAGPostResultProcessor(PostResultProcessor):
         results = result_group.get(interval=0.05, timeout=120)
         if self.stop_background_thread:
             return 0
+
+        chunks_added = 0
+        chunks_fallback = 0
+        chunks_skipped = 0
+
         for nth_result, result in enumerate(results):
+            url = chosen_rag[nth_result].get('url', '')
             if result[0] == False:
+                chunks_skipped += 1
+                logger.info(f"RAG [{nth_result+1}] SKIPPED (page_fetcher returned False) url={url[:80]}")
                 continue
             else:
                 text_for_query, response_url, document_type, body, url, json = result
@@ -206,28 +220,41 @@ class RAGPostResultProcessor(PostResultProcessor):
                         fallback_text = fallback_text + new_content
                         fallback_tokens = fallback_tokens + len(new_content.split())
 
-                    # Getting search provider from the last item is questionable practice D.A.N.
-                    # logger.info(f'RAG {item["searchprovider"]} PageFetcherFactory adding prompt content from page :\nurl : {url}\ncontent_url : {content_url}\nresponse_url:{response_url}')
                     if new_content := text_for_query:
-                        # is_full = rag_prompt.put_chunk(new_content, url=url, type=document_type, filter_file_type=(not content_url))
+                        source = "page" if text_for_query != f"body : {body}" else "summary"
                         is_full = rag_prompt.put_chunk(new_content, url=url, type=document_type, filter_file_type=True)
                         if not rag_prompt.is_last_chunk_added():
                             summary_page_text = self.format_result_as_page(chosen_rag[nth_result]['body'], rag_prompt.get_last_chunk_status())
                             is_full = rag_prompt.put_chunk(summary_page_text, url=url, type=document_type, filter_file_type=True)
                             if not rag_prompt.is_last_chunk_added():
-                                warn =  f"RAG Chunk not added : {rag_prompt.get_last_chunk_status()}"
+                                warn = f"RAG Chunk not added : {rag_prompt.get_last_chunk_status()}"
                                 self._log_n_store_warn(url=url, warn=warn, buffer=fetch_prompt_errors)
                                 fetch_prompt_errors[url] = warn
+                                chunks_skipped += 1
+                                logger.info(f"RAG [{nth_result+1}] REJECTED status={rag_prompt.get_last_chunk_status()} url={url[:80]}")
+                            else:
+                                chunks_fallback += 1
+                                logger.info(f"RAG [{nth_result+1}] ADDED via summary fallback tokens={rag_prompt.get_num_tokens()} url={url[:80]}")
+                        else:
+                            chunks_added += 1
+                            logger.info(f"RAG [{nth_result+1}] ADDED via {source} tokens={rag_prompt.get_num_tokens()} url={url[:80]}")
 
-                        logger.debug(f'RAG : max_tokens:{max_tokens} num_tokens {rag_prompt.get_num_tokens()} is_full:{rag_prompt.is_full()}')
                         if is_full:
+                            logger.info(f"RAG: token budget exhausted after {nth_result+1} results")
                             break
                     else:
                         summary_page_text = self.format_result_as_page(chosen_rag[nth_result]['body'], "NO CONTENT")
                         is_full = rag_prompt.put_chunk(summary_page_text, url=url, type=document_type, filter_file_type=True)
                         if not rag_prompt.is_last_chunk_added():
                             warn = f'RAG No content found in {url} max_tokens:{max_tokens} num_tokens {rag_prompt.get_num_tokens()} is_full:{rag_prompt.is_full()} JSON:{json}'
-                            self._log_n_store_warn(url=url,warn=warn,buffer=fetch_prompt_errors)
+                            self._log_n_store_warn(url=url, warn=warn, buffer=fetch_prompt_errors)
+                            chunks_skipped += 1
+                            logger.info(f"RAG [{nth_result+1}] REJECTED no content url={url[:80]}")
+                        else:
+                            chunks_fallback += 1
+                            logger.info(f"RAG [{nth_result+1}] ADDED via body-only fallback tokens={rag_prompt.get_num_tokens()} url={url[:80]}")
+
+        logger.info(f"RAG summary: added={chunks_added} fallback={chunks_fallback} skipped={chunks_skipped} prompt_tokens={rag_prompt.get_num_tokens()}/{max_tokens}")
 
         new_prompt_text = rag_prompt.get_promp_text()
         logger.debug(f"\nRAG Prompt:\n\t{new_prompt_text}")
@@ -297,6 +324,13 @@ class RAGPostResultProcessor(PostResultProcessor):
         if settings.SWIRL_DEFAULT_RESULT_BLOCK:
             rag_result['result_block'] = getattr(settings, 'SWIRL_DEFAULT_RESULT_BLOCK', 'ai_summary')
         rag_result['rag_query_items'] = [str(item['swirl_id']) for item in chosen_rag]
+        rag_result['additional_content'] = {
+            'sources': [
+                {'title': item.get('title', ''), 'url': item.get('url', '')}
+                for item in chosen_rag
+                if item.get('url')
+            ]
+        }
 
         result = Result.objects.create(owner=self.search.owner, search_id=self.search, provider_id=5, searchprovider='ChatGPT', query_string_to_provider=new_prompt_text[:256], query_to_provider='None', status='READY', retrieved=1, found=1, json_results=[rag_result], time=0.0)
         result.save()

--- a/swirl/rag_prompt.py
+++ b/swirl/rag_prompt.py
@@ -38,13 +38,8 @@ class RagPrompt():
         f"\n\n\n\n--- Final Instructions ---\nIn your response do not assume people with vastly different work histories are the same person. "
         f"If the query appears to be a proper name, focus on answering the question, 'Who is?' or 'What is?', as appropriate. "
         f"If the query appears to be a question, then try to answer it. "
-        f"For the list of sources, use the HTML tags and format in the example below, do not generate duplicate entries, one entry per source.:\n"
-        f"\n<p>"
-        f"\n<br><b>Sources:</b>"
-        f"\n<br><i>example description 1</i> &nbsp;&nbsp;&nbsp; <b>example URL or source name 1</b>"
-        f"\n<br><i>example description 2</i> &nbsp;&nbsp;&nbsp; <b>example URL or source name 2</b>"
-        f"\n</p>"
-        f"\n\nEnclose your response in HTML tags <p></p> and insert a <br> HTML tag every two sentences."
+        f"At the end of your response, list your sources in plain text, one per line, with a short description followed by the URL or source name. "
+        f"Do not generate duplicate source entries. Do not use HTML tags in your response."
         )
 
     def get_num_tokens(self):

--- a/swirl/serializers.py
+++ b/swirl/serializers.py
@@ -178,9 +178,10 @@ class QueryTransformNoCredentialsSerializer(serializers.ModelSerializer):
 
 class DetailSearchRagSerializer(serializers.Serializer):
     message = serializers.CharField(required=True, allow_blank=True)
+    additional_content = serializers.DictField(required=False, default=dict)
 
     class Meta:
-        fields = ["message"]
+        fields = ["message", "additional_content"]
 
 
 # Minimal Serializers for drf-spectacular OpenAPI documentation only

--- a/swirl/templates/index.html
+++ b/swirl/templates/index.html
@@ -101,7 +101,7 @@
       <h3>Administration</h3>
       <div class="dash-links">
         <a href="/admin/" target="_blank">Admin Console</a>
-        <a href="/swirl/admin/analytics/" target="_blank">Analytics</a>
+        <a href="/admin/activity/" target="_blank">Analytics</a>
         <a href="https://docs.swirlaiconnect.com/" target="_blank">Documentation</a>
         <a href="https://github.com/swirlai/swirl-search" target="_blank">GitHub</a>
         <a href="https://swirlaiconnect.com/faq/" target="_blank">Support</a>

--- a/swirl/views.py
+++ b/swirl/views.py
@@ -66,6 +66,24 @@ def get_session_data_with_db_fallback(request):
     """
     import jwt as _jwt
 
+    # Fast path: galaxy sends the live MSAL token inline with every request.
+    # Use it directly and write it through to OauthToken so the DB stays fresh.
+    ms_header_token = request.headers.get('Authorizationmicrosoft', '').strip()
+    if ms_header_token and getattr(request, 'user', None) and request.user.is_authenticated:
+        try:
+            OauthToken.objects.update_or_create(
+                owner=request.user, idp='Microsoft',
+                defaults={'token': ms_header_token, 'refresh_token': ''},
+            )
+            logger.debug(f"get_session_data_with_db_fallback: stored inline MS token for {request.user}")
+        except Exception as _e:
+            logger.debug(f"get_session_data_with_db_fallback: inline token DB write failed: {_e}")
+        return {
+            'microsoft_access_token': ms_header_token,
+            'microsoft_refresh_token': '',
+            'microsoft_access_token_expiration_time': 9999999999,
+        }
+
     session_data = Authenticator().get_session_data(request)
 
     if session_data:

--- a/swirl/views_helpers/search_rag.py
+++ b/swirl/views_helpers/search_rag.py
@@ -25,7 +25,14 @@ class SearchRag:
         if rag_query_items and isinstance(rag_query_items, str):
             self.rag_query_items = rag_query_items.split(",")
 
-    def get_rag_result(self) -> tuple[str, dict[str, str]]:
+    def _extract_result(self, json_result: dict) -> tuple:
+        """Return (body_text, additional_content) from a stored rag json_result."""
+        body = json_result.get("body", [None])
+        body_text = body[0] if isinstance(body, (list, tuple)) else body
+        additional_content = json_result.get("additional_content", {})
+        return body_text, additional_content
+
+    def get_rag_result(self) -> tuple:
         isRagItemsUpdated = False
         try:
             rag_result = Result.objects.get(
@@ -47,9 +54,10 @@ class SearchRag:
                 == set(self.rag_query_items)
             )
             if rag_result and not isRagItemsUpdated:
-                if rag_result.json_results[0]["body"][0]:
-                    return rag_result.json_results[0]["body"][0]
-                return False
+                body_text, additional_content = self._extract_result(rag_result.json_results[0])
+                if body_text:
+                    return body_text, additional_content
+                return False, {}
         except:
             pass
         rag_processor = RAGPostResultProcessor(
@@ -62,18 +70,25 @@ class SearchRag:
         if rag_processor.validate():
             result = rag_processor.process(should_return=True)
             if result == 0:
-                return "Please check the OpenAI or Azure/OpenAI credentials in your environment."
+                return "Please check the OpenAI or Azure/OpenAI credentials in your environment.", {}
 
             if self.search_id in instances:
                 del instances[self.search_id]
 
-            return result.json_results[0]["body"][0]
+            return self._extract_result(result.json_results[0])
 
-    def process_rag(self) -> dict[str, str]:
-        result = ""
+        return "", {}
+
+    def process_rag(self) -> dict:
+        body_text = ""
+        additional_content = {}
         try:
             result = self.get_rag_result()
+            if isinstance(result, tuple):
+                body_text, additional_content = result
+            else:
+                body_text = result
         except RagError as err:
             logger.error(f"{self}: Rag Error {err}")
 
-        return {"message": result}
+        return {"message": body_text, "additional_content": additional_content}


### PR DESCRIPTION
## Branching Reminders
X For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
- rag_prompt.py: remove HTML formatting instructions from footer (galaxy renders plain text)
- processors/rag.py: populate additional_content.sources from chosen_rag items; add INFO instrumentation (candidate list, per-chunk ADDED/REJECTED/SKIPPED, token budget summary)
- views_helpers/search_rag.py: thread additional_content through get_rag_result/process_rag
- serializers.py: DetailSearchRagSerializer exposes additional_content field
- views.py: get_session_data_with_db_fallback reads Authorizationmicrosoft header directly, stores/returns token without requiring MSAL session or OauthToken DB lookup

## Testing and Validation
Unit tests

## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [X] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
