### PR TITLE
DS-5598: restore /swirl/ to serve index view instead of redirecting to /admin/

### DIFF
--- a/swirl/urls.py
+++ b/swirl/urls.py
@@ -46,8 +46,8 @@ urlpatterns = [
     path('sapi/detail-search-rag/', views.DetailSearchRagView.as_view(), name='detail-search-rag'),
     path('sapi/is_chat_ai_provider_exists', views.IsChatAIProviderExists.as_view({'get': 'list'}), name='is-chat-ai-provider-exists'),
 
-    path('', RedirectView.as_view(url='/admin/', permanent=False), name='index'),
-    path('index.html', RedirectView.as_view(url='/admin/', permanent=False), name='index_html'),
+    path('', views.index, name='index'),
+    path('index.html', views.index, name='index_html'),
     path('error.html', views.error, name='error'),
     path('authenticators.html', views.authenticators, name='authenticators'),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),


### PR DESCRIPTION

## Branching Reminders
X For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
The redirect to /admin/ requires authentication. QA tests navigate to /swirl/ unauthenticated and hit the Django login wall, so Authenticators and Upload Query Transform CSV links cannot be found. Restored original views.index behavior from main branch.

## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [X] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
