### PR TITLE
test(DS-5598): regression tests for get_encoding_model and RAG additional_content

### DIFF
--- a/swirl/tests/test_aiprovider.py
+++ b/swirl/tests/test_aiprovider.py
@@ -656,3 +656,51 @@ def test_factory_llm_wrapper_get_provider_returns_selected(superuser):
         factory = _factory()
         result = factory.alloc_ai_provider('chat', options={'unit_test': True})
     assert result.get_provider().name == 'My Model'
+
+
+# ===========================================================================
+# LLMWrapper.get_encoding_model tests
+#
+# Regression coverage for DS-5598: rag.py calls self.client.get_encoding_model()
+# during background_process(). Before the fix this raised AttributeError on
+# LLMWrapper, breaking /api/swirl/sapi/detail-search-rag/ with a 500.
+# ===========================================================================
+
+def _alloc_wrapper(superuser, model):
+    _make_provider(superuser, name=f'Provider-{model}', model=model,
+                   tags=['rag'], defaults=['rag'])
+    with patch('swirl.ai_provider.litellm'):
+        return _factory().alloc_ai_provider('rag', options={'unit_test': True})
+
+
+@pytest.mark.django_db
+def test_llmwrapper_get_encoding_model_known_openai_model(superuser):
+    wrapper = _alloc_wrapper(superuser, 'gpt-4o')
+    assert wrapper.get_encoding_model() == 'gpt-4o'
+
+
+@pytest.mark.django_db
+def test_llmwrapper_get_encoding_model_strips_known_provider_prefix(superuser):
+    wrapper = _alloc_wrapper(superuser, 'azure/gpt-4o')
+    assert wrapper.get_encoding_model() == 'gpt-4o'
+
+
+@pytest.mark.django_db
+def test_llmwrapper_get_encoding_model_falls_back_for_unknown_model(superuser):
+    wrapper = _alloc_wrapper(superuser, 'anthropic/claude-3-5-sonnet-20241022')
+    assert wrapper.get_encoding_model() == 'gpt-4o'
+
+
+@pytest.mark.django_db
+def test_llmwrapper_get_encoding_model_falls_back_for_arbitrary_deployment(superuser):
+    wrapper = _alloc_wrapper(superuser, 'azure/my-custom-deployment')
+    assert wrapper.get_encoding_model() == 'gpt-4o'
+
+
+@pytest.mark.django_db
+def test_llmwrapper_get_encoding_model_handles_empty_model(superuser):
+    _make_provider(superuser, name='NoModel', model='', config={'family': 'openai'},
+                   tags=['rag'], defaults=['rag'])
+    with patch('swirl.ai_provider.litellm'):
+        wrapper = _factory().alloc_ai_provider('rag', options={'unit_test': True})
+    assert wrapper.get_encoding_model() == 'gpt-4o'

--- a/swirl/tests/test_search_rag.py
+++ b/swirl/tests/test_search_rag.py
@@ -1,0 +1,106 @@
+"""
+Unit tests for the SearchRag helper and DetailSearchRagSerializer.
+
+Covers DS-5598 additional_content (RAG citations) plumbing:
+- SearchRag._extract_result returns (body_text, additional_content)
+- DetailSearchRagSerializer accepts and round-trips additional_content
+
+Run with:  pytest swirl/tests/test_search_rag.py -v
+"""
+
+import pytest
+
+from swirl.serializers import DetailSearchRagSerializer
+from swirl.views_helpers.search_rag import SearchRag
+
+
+class _FakeGet:
+    def __init__(self, data):
+        self._data = data
+
+    def dict(self):
+        return dict(self._data)
+
+
+class _FakeRequest:
+    def __init__(self, data=None):
+        self.GET = _FakeGet(data or {})
+
+
+def _make_search_rag(rag_items=None):
+    data = {}
+    if rag_items is not None:
+        data["rag_items"] = rag_items
+    return SearchRag(_FakeRequest(data))
+
+
+# ---------------------------------------------------------------------------
+# SearchRag._extract_result
+# ---------------------------------------------------------------------------
+
+def test_extract_result_returns_body_and_additional_content():
+    sr = _make_search_rag()
+    json_result = {
+        "body": ["rag answer text"],
+        "additional_content": {"sources": [{"url": "https://example.com"}]},
+    }
+    body_text, additional_content = sr._extract_result(json_result)
+    assert body_text == "rag answer text"
+    assert additional_content == {"sources": [{"url": "https://example.com"}]}
+
+
+def test_extract_result_missing_additional_content_returns_empty_dict():
+    sr = _make_search_rag()
+    json_result = {"body": ["just the body"]}
+    body_text, additional_content = sr._extract_result(json_result)
+    assert body_text == "just the body"
+    assert additional_content == {}
+
+
+def test_extract_result_body_as_scalar():
+    sr = _make_search_rag()
+    json_result = {"body": "scalar body", "additional_content": {"sources": []}}
+    body_text, additional_content = sr._extract_result(json_result)
+    assert body_text == "scalar body"
+    assert additional_content == {"sources": []}
+
+
+def test_extract_result_body_missing_returns_none():
+    sr = _make_search_rag()
+    body_text, additional_content = sr._extract_result({})
+    assert body_text is None
+    assert additional_content == {}
+
+
+# ---------------------------------------------------------------------------
+# DetailSearchRagSerializer
+# ---------------------------------------------------------------------------
+
+def test_serializer_accepts_message_and_additional_content():
+    serializer = DetailSearchRagSerializer(data={
+        "message": "answer",
+        "additional_content": {"sources": [{"url": "https://example.com"}]},
+    })
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["message"] == "answer"
+    assert serializer.validated_data["additional_content"] == {
+        "sources": [{"url": "https://example.com"}],
+    }
+
+
+def test_serializer_additional_content_defaults_to_empty_dict():
+    serializer = DetailSearchRagSerializer(data={"message": "answer"})
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["additional_content"] == {}
+
+
+def test_serializer_allows_blank_message():
+    serializer = DetailSearchRagSerializer(data={"message": ""})
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["message"] == ""
+
+
+def test_serializer_requires_message_key():
+    serializer = DetailSearchRagSerializer(data={"additional_content": {}})
+    assert not serializer.is_valid()
+    assert "message" in serializer.errors


### PR DESCRIPTION
## Summary

This PR adds **13 regression tests** for the DS-5598 work that previously merged via #1842. The DS-5598 functionality is already in `develop`; this PR adds the missing test coverage on top of it.

### New tests

- **`swirl/tests/test_aiprovider.py`** (+5 tests): `LLMWrapper.get_encoding_model`
  - Covers the `AttributeError: 'LLMWrapper' object has no attribute 'get_encoding_model'` that crashed `/api/swirl/sapi/detail-search-rag/` with a 500 before commit `7f114289`.
  - Cases: known OpenAI model, `azure/` prefix stripping, Anthropic fallback to `gpt-4o`, arbitrary deployment fallback, empty model fallback.
- **`swirl/tests/test_search_rag.py`** (+8 tests, new file): RAG citations plumbing
  - `SearchRag._extract_result`: body/`additional_content` tuple extraction, scalar body, missing-`additional_content` default, missing-body default.
  - `DetailSearchRagSerializer`: round-trips `additional_content`, defaults to `{}`, allows blank message, requires `message` key.

Result: **129 tests pass** (was 116).

## DS-5598 history (already merged via #1842, included for context)

| Commit | Description |
| --- | --- |
| `460bd05d` | feat: add fetch-document proxy and Microsoft token DB fallback |
| `e1fdea9e` | feat: design improvements — admin console, performance, relevancy, swirl.py, README |
| `7f114289` | feat: add AIProvider model, factory, tests, RAG fix, banner fix |
| `6430cfeb` | fix: update test_cgptqp_* mocks for new AIProvider completion path |
| `79182632` | fix: handle empty-string env vars from docker-compose shell substitution in settings.py |
| `002fe00b` | fix: guard env.int() against empty-string docker-compose substitution |
| `893520ad` | feat: RAG citations, plain-text response, MS token header fast-path, instrumentation |
| `0bc000a5` | fix: correct Analytics link on home page to /admin/activity/ |
| `fcbc6ab4` | fix: restore Authenticators and Upload Query Transform CSV links in admin |
| `3dc9f4c2` | fix: populate ai_model in RAG response; disable NLResearch QA scenarios |
| `f4f9ae18` | fix: restore /swirl/ to serve index view instead of redirecting to /admin/ |
| `3045d7d4` | **test: this PR** — regression tests for get_encoding_model & RAG additional_content |

The PR diff is **just the new tests** — the underlying code is unchanged.

## Test plan

- [x] `pytest swirl/tests/` — 129 passed (was 116)
- [x] `pytest swirl/tests/test_aiprovider.py -k encoding` — 5 new tests pass
- [x] `pytest swirl/tests/test_search_rag.py` — 8 new tests pass
- [ ] CI green on this PR
- [ ] QA suite (`swirl-search-qa @ develop`, `e6508b2`) runs cleanly against the docker image once built