### PR TITLE
DS-5598: realign QA Suite provider PATCH endpoints after LinkedIn removal

### DIFF
--- a/.github/workflows/qa-suite.yml
+++ b/.github/workflows/qa-suite.yml
@@ -60,20 +60,21 @@ jobs:
             -u admin:"$PASSWORD" \
             -H "Content-Type: application/json" \
             -d "$JSON"
-      - name: PATCH the LinkedIn PSE Config
-        env:
-          JSON: ${{ secrets.QA_PSE_LINKEDIN }}
-          API_ENDPOINT: http://localhost:8000/swirl/searchproviders/3/
-          PASSWORD: ${{ secrets.QA_ADMIN_PW }}
-        run: |
-          curl -X PATCH "$API_ENDPOINT" \
-            -u admin:"$PASSWORD" \
-            -H "Content-Type: application/json" \
-            -d "$JSON"
+      # DS-5598: LinkedIn was removed from SearchProviders/preloaded.json
+      # (it was a Google PSE flavour pointing at linkedin.com that the team
+      # is not maintaining). The previous "PATCH the LinkedIn PSE Config"
+      # step targeted provider ID 3, which after the removal is no longer
+      # LinkedIn — it's "Documentation - SWIRL AI". Removing this step
+      # avoids overwriting the Documentation provider's config with the
+      # stale LinkedIn PSE secret.
+      #
+      # The SWIRL Docs PSE config moved from provider ID 4 -> ID 3 because
+      # LinkedIn no longer occupies a slot above it; the API_ENDPOINT
+      # below is updated to match.
       - name: PATCH the SWIRL Docs PSE Config
         env:
           JSON: ${{ secrets.QA_PSE_DOCS }}
-          API_ENDPOINT: http://localhost:8000/swirl/searchproviders/4/
+          API_ENDPOINT: http://localhost:8000/swirl/searchproviders/3/
           PASSWORD: ${{ secrets.QA_ADMIN_PW }}
         run: |
           curl -X PATCH "$API_ENDPOINT" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
SearchProviders/preloaded.json dropped its LinkedIn entry as part of the DS-5598 standardisation pass; that shifted every entry below it up by one slot:

  before                          after
  ----------------------------    ---------------------------
  1  Google Web                  1  Web - Google PSE
  2  Google News                 2  News - Google News RSS
  3  LinkedIn                    3  Documentation - SWIRL AI   <- shifted
  4  Swirl Documentation         4  Web - Internet Archive     <- shifted

The qa-suite workflow still patched ID 3 with the LinkedIn PSE secret and ID 4 with the SWIRL Docs PSE secret. In run #318 that gave the Documentation provider LinkedIn-flavoured credentials (broken PSE cx for docs.swirlaiconnect.com) and overwrote the Internet Archive provider with the SWIRL Docs config. That cascaded into 4 scenario failures (3 swirl_docs.feature + provider_rag.feature:14).

Fix:
- Drop the LinkedIn PATCH step entirely (no LinkedIn provider to patch).
- Move the SWIRL Docs PATCH endpoint from ID 4 -> ID 3.
- The QA_PSE_LINKEDIN repo secret is left in place but unreferenced; the admin can prune it at their leisure.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
