### PR TITLE
DS-5598: realign test-build-pipeline QA Suite PATCH endpoints

### DIFF
--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -159,20 +159,22 @@ jobs:
               -u admin:"$PASSWORD" \
               -H "Content-Type: application/json" \
               -d "$JSON"
-        - name: PATCH the LinkedIn PSE Config
-          env:
-            JSON: ${{ secrets.QA_PSE_LINKEDIN }}
-            API_ENDPOINT: http://localhost:8000/swirl/searchproviders/3/
-            PASSWORD: ${{ secrets.QA_ADMIN_PW }}
-          run: |
-            curl -X PATCH "$API_ENDPOINT" \
-              -u admin:"$PASSWORD" \
-              -H "Content-Type: application/json" \
-              -d "$JSON"
+        # DS-5598: LinkedIn was removed from SearchProviders/preloaded.json
+        # (it was a Google PSE flavour pointing at linkedin.com that the team
+        # is not maintaining). The previous "PATCH the LinkedIn PSE Config"
+        # step targeted provider ID 3, which after the removal is no longer
+        # LinkedIn — it's "Documentation - SWIRL AI". Removing this step
+        # avoids overwriting the Documentation provider's config with the
+        # stale LinkedIn PSE secret.
+        #
+        # The SWIRL Docs PSE config moved from provider ID 4 -> ID 3 because
+        # LinkedIn no longer occupies a slot above it; the API_ENDPOINT
+        # below is updated to match. This mirrors the equivalent edit on
+        # qa-suite.yml in PR #1850.
         - name: PATCH the SWIRL Docs PSE Config
           env:
             JSON: ${{ secrets.QA_PSE_DOCS }}
-            API_ENDPOINT: http://localhost:8000/swirl/searchproviders/4/
+            API_ENDPOINT: http://localhost:8000/swirl/searchproviders/3/
             PASSWORD: ${{ secrets.QA_ADMIN_PW }}
           run: |
             curl -X PATCH "$API_ENDPOINT" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
PR #1850 fixed `.github/workflows/qa-suite.yml` (the manual QA Suite workflow) after the LinkedIn provider was removed from SearchProviders/preloaded.json — drop the LinkedIn PATCH step and move SWIRL Docs from id 4 to id 3. The equivalent qa-suite stage in test-build-pipeline.yml (the automated push-triggered pipeline) was missed and still PATCHed:

  - id 3 with QA_PSE_LINKEDIN (now an empty secret -> 400 "name required" -> provider unchanged -> Documentation - SWIRL AI remains inactive)
  - id 4 with QA_PSE_DOCS (now Web - Internet Archive, which got the SWIRL Docs Google PSE credentials grafted onto it)

The visible symptom in Test and Build Pipeline #324 was that all three swirl_docs.feature search scenarios failed with results coming from Hacker News, ArXiv, and Google News RSS instead of Documentation — because Documentation was never activated and the tag-prefixed `Swirl:` query falls back to default+active providers.

Apply the same fix here as in PR #1850.


## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
