### PR TITLE
DS-5598: honour partial=True on SearchProvider PATCH

### DIFF
--- a/swirl/views.py
+++ b/swirl/views.py
@@ -405,7 +405,7 @@ class SearchProviderViewSet(viewsets.ModelViewSet):
 
     ########################################
 
-    def update(self, request, pk=None):
+    def update(self, request, pk=None, partial=False):
 
         # check permissions
         if not request.user.has_perm('swirl.change_searchprovider'):
@@ -417,7 +417,14 @@ class SearchProviderViewSet(viewsets.ModelViewSet):
 
         searchprovider = SearchProvider.objects.get(pk=pk)
         searchprovider.date_updated = datetime.now()
-        serializer = SearchProviderSerializer(instance=searchprovider, data=request.data)
+        # DS-5598: honour the ``partial`` flag so PATCH requests can omit
+        # fields. Previously this view always validated against the full
+        # ModelSerializer schema, which made PATCH behave identically to
+        # PUT — any body missing required fields (e.g. ``name``) returned
+        # 400 ``"This field is required."``. The qa-suite secret-injection
+        # workflow (and any external integration sending a partial PATCH)
+        # relies on the standard DRF partial-update semantics.
+        serializer = SearchProviderSerializer(instance=searchprovider, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         # security review for 1.7 - OK, saved with owner
         serializer.save(owner=self.request.user)
@@ -441,7 +448,7 @@ class SearchProviderViewSet(viewsets.ModelViewSet):
         return Response('SearchProvider Object Deleted', status=status.HTTP_410_GONE)
 
     def partial_update(self, request, pk=None):
-        return self.update(request, pk)
+        return self.update(request, pk, partial=True)
 
     # 10a: health-check endpoint — GET /swirl/searchproviders/{id}/test/
     # Runs a minimal test query against the provider and reports OK or FAIL.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
`SearchProviderViewSet.partial_update` returned `self.update(request, pk)` and `update()` constructed `SearchProviderSerializer(instance=..., data=request.data)` — i.e. PATCH was indistinguishable from PUT and required the full body. Any request omitting a CharField (e.g. `name`, which is required at the model level) returned 400:

  {"name":["This field is required."]}

Visible in Test and Build Pipeline #325: both
`PATCH /swirl/searchproviders/1/` (Web - Google PSE) and `PATCH /swirl/searchproviders/3/` (Documentation - SWIRL AI) fired during the qa-suite stage with body payloads from the QA_PSE_WEB / QA_PSE_DOCS secrets that intentionally omit `name` (so credential rotation doesn't accidentally rename the provider). Both 400'd. The two providers stayed inactive, and the downstream qa-suite scenarios that depend on those providers being live (`swirl_docs.feature`, `search_core.feature`) failed.

Add a `partial` kwarg to `update()` (defaulting to False for PUT so behaviour is unchanged) and route `partial_update()` through it with `partial=True`. This matches the standard DRF ModelViewSet semantics that consumers (Galaxy admin UI, secret-injection workflows, external integrations) expect from PATCH.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
