### PR TITLE
DS-5598: dump swirl backend logs in qa-suite step

### DIFF
--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -205,6 +205,24 @@ jobs:
             cat .env.qa
             echo "========"
             docker run --net=host --env-file .env.qa -t swirlai/swirl-search-qa:automated-tests-develop sh -c "behave --tags=qa_suite,community"
+        # DS-5598: dump every ./logs/*.log produced by `python swirl.py
+        # start` into the qa-suite step output so backend WARNING /
+        # ERROR lines (RAG-DIAG, exception tracebacks, AIProvider
+        # allocation messages) appear in the GitHub Actions log. Without
+        # this the swirl backend logs live on the runner's temp disk
+        # and vanish when the job ends — invisible in the test-build-
+        # pipeline artifact. `if: always()` runs the step even when
+        # behave fails (which is exactly when the logs are most useful).
+        - name: Dump swirl backend logs
+          if: always()
+          run: |
+            shopt -s nullglob
+            for f in logs/*.log; do
+              echo "=================================================="
+              echo "===== $f"
+              echo "=================================================="
+              cat "$f" || true
+            done
 
     swirl-docker:
       needs: qa-suite


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
After the qa-suite docker run, cat every `./logs/*.log` written by `python swirl.py start` into the step output. Without this the backend's WARNING / ERROR lines (including the RAG-DIAG diagnostic added in PR #1861 and any AIProvider allocation exceptions) sit on the runner's temp disk and never reach the workflow artifact — making it impossible to root-cause why the 7 RAG metadata scenarios in `rag.feature` and `provider_rag.feature` rendered "Generated in Xs" instead of "Generated by <model> in Xs" in Test and Build Pipeline #327. The qa-suite log already shows behave's stdout but nothing from the backend.

`if: always()` is critical here — behave failing is exactly when the backend logs are most valuable.


## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
