### PR TITLE
DS-5598: make dump swirl backend logs step actually find the logs

### DIFF
--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -213,16 +213,40 @@ jobs:
         # and vanish when the job ends — invisible in the test-build-
         # pipeline artifact. `if: always()` runs the step even when
         # behave fails (which is exactly when the logs are most useful).
+        #
+        # The first iteration of this step (PR #1864) only globbed
+        # `logs/*.log` from the default cwd and the step finished in 0s
+        # in run #329 — either the cwd isn't where swirl writes its
+        # logs, or the logs are nested under a subdir. This version
+        # falls back to a workspace-wide find so we actually see the
+        # backend output regardless of cwd resolution, and also prints
+        # the cwd / workspace listing up front to make future debugging
+        # one read of the step output rather than two iterations.
         - name: Dump swirl backend logs
           if: always()
           run: |
+            set +e
+            echo "===== pwd: $(pwd)"
+            echo "===== GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}"
+            echo "===== top-level listing:"
+            ls -la
+            echo "===== ./logs (if present):"
+            ls -la ./logs 2>/dev/null || echo "(no ./logs in $(pwd))"
+            echo "===== find workspace for *.log under */logs/*:"
+            find "${GITHUB_WORKSPACE:-.}" -name "*.log" -path "*/logs/*" 2>/dev/null
             shopt -s nullglob
-            for f in logs/*.log; do
+            log_files=( "${GITHUB_WORKSPACE:-.}"/logs/*.log )
+            if [ ${#log_files[@]} -eq 0 ]; then
+              echo "===== no logs/*.log under GITHUB_WORKSPACE; searching workspace"
+              mapfile -t log_files < <(find "${GITHUB_WORKSPACE:-.}" -name "*.log" -path "*/logs/*" 2>/dev/null)
+            fi
+            for f in "${log_files[@]}"; do
               echo "=================================================="
               echo "===== $f"
               echo "=================================================="
               cat "$f" || true
             done
+            echo "===== Dump swirl backend logs: done"
 
     swirl-docker:
       needs: qa-suite


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
The first iteration (PR #1864) only globbed `logs/*.log` from the default cwd. In Test and Build Pipeline #329 the step fired but finished in 0s with no output — meaning the glob matched nothing. Either the runner's default cwd isn't where `python swirl.py start` writes its log files, or the logs landed in a subdir we weren't expecting.

Expand the step to:

1. Print `pwd`, `$GITHUB_WORKSPACE`, the top-level listing, and the contents of `./logs` up front so it's obvious where the runner is and what's actually in the workspace.
2. Run a workspace-wide `find … -name "*.log" -path "*/logs/*"` so we see every log file regardless of cwd resolution.
3. Glob `$GITHUB_WORKSPACE/logs/*.log` directly (absolute path), and fall back to the `find` result if that turns up empty.
4. `cat` every matched file with banner separators so RAG-DIAG and the AIProvider allocation messages land in the qa-suite step output.

`if: always()` still ensures the step runs even when behave fails.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
