### PR TITLE
ci: mount swirl-search preloaded.json into qa-suite container

### DIFF
--- a/.github/workflows/qa-suite.yml
+++ b/.github/workflows/qa-suite.yml
@@ -104,7 +104,16 @@ jobs:
           echo "========"
           cat .env.qa
           echo "========"
-          docker run --net=host --env-file .env.qa -t swirlai/swirl-search-qa:automated-tests-develop sh -c "behave --tags=qa_suite,community --exclude nl_research"
+          # Mount swirl-search-public's preloaded.json files into the QA
+          # container so data_examples/_preloaded.py can resolve them via
+          # $SWIRL_PRELOADED_DIR. Without this the loader raises
+          # FileNotFoundError on the first import inside behave.
+          docker run --net=host --env-file .env.qa \
+            -v "${{ github.workspace }}/SearchProviders:/swirl/SearchProviders:ro" \
+            -v "${{ github.workspace }}/AIProviders:/swirl/AIProviders:ro" \
+            -e SWIRL_PRELOADED_DIR=/swirl \
+            -t swirlai/swirl-search-qa:automated-tests-develop \
+            sh -c "behave --tags=qa_suite,community --exclude nl_research"
       - name: Upload Log Files
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -204,7 +204,16 @@ jobs:
             echo "========"
             cat .env.qa
             echo "========"
-            docker run --net=host --env-file .env.qa -t swirlai/swirl-search-qa:automated-tests-develop sh -c "behave --tags=qa_suite,community"
+            # Mount swirl-search-public's preloaded.json files into the
+            # QA container so data_examples/_preloaded.py can resolve them
+            # via $SWIRL_PRELOADED_DIR. Without this the loader raises
+            # FileNotFoundError on the first import inside behave.
+            docker run --net=host --env-file .env.qa \
+              -v "${{ github.workspace }}/SearchProviders:/swirl/SearchProviders:ro" \
+              -v "${{ github.workspace }}/AIProviders:/swirl/AIProviders:ro" \
+              -e SWIRL_PRELOADED_DIR=/swirl \
+              -t swirlai/swirl-search-qa:automated-tests-develop \
+              sh -c "behave --tags=qa_suite,community"
         # DS-5598: dump every ./logs/*.log produced by `python swirl.py
         # start` into the qa-suite step output so backend WARNING /
         # ERROR lines (RAG-DIAG, exception tracebacks, AIProvider

--- a/.github/workflows/testing-wip.yml
+++ b/.github/workflows/testing-wip.yml
@@ -116,7 +116,15 @@ jobs:
           echo "========"
           cat .env.qa
           echo "========"
-          docker run --net=host --env-file .env.qa -t swirlai/swirl-search-qa:${{ github.event.inputs.qa_image }} sh -c "behave --no-capture --tags=${{ github.event.inputs.behave_tags }}"
+          # Mount swirl-search-public's preloaded.json files into the QA
+          # container so data_examples/_preloaded.py can resolve them via
+          # $SWIRL_PRELOADED_DIR. Required since the loader refactor.
+          docker run --net=host --env-file .env.qa \
+            -v "${{ github.workspace }}/SearchProviders:/swirl/SearchProviders:ro" \
+            -v "${{ github.workspace }}/AIProviders:/swirl/AIProviders:ro" \
+            -e SWIRL_PRELOADED_DIR=/swirl \
+            -t swirlai/swirl-search-qa:${{ github.event.inputs.qa_image }} \
+            sh -c "behave --no-capture --tags=${{ github.event.inputs.behave_tags }}"
       - name: Upload Log Files
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
The swirl-search-qa data_examples loader resolves SP/AIP names by reading the canonical SearchProviders/preloaded.json and AIProviders/preloaded.json from a sibling swirl-search checkout (or the path in $SWIRL_PRELOADED_DIR). The qa-suite Docker image, however, only bundles the QA repo itself, so inside the container neither location resolves — behave crashed with FileNotFoundError on the first step import.

Mount swirl-search-public's two preloaded directories into the container read-only and set SWIRL_PRELOADED_DIR=/swirl. Applied to qa-suite.yml, test-build-pipeline.yml, and testing-wip.yml so a manual behave run via the WIP workflow doesn't hit the same surprise.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
