### PR TITLE
Restore content-type + source-slug tags that back tag-prefix queries

### DIFF
--- a/SearchProviders/arxiv.json
+++ b/SearchProviders/arxiv.json
@@ -22,8 +22,10 @@
     "credentials": "",
     "eval_credentials": "",
     "tags": [
-        "Public",
+        "arXiv",
+        "Articles",
         "STM",
+        "Public",
         "RAG-ready"
     ]
 }

--- a/SearchProviders/asana.json
+++ b/SearchProviders/asana.json
@@ -27,6 +27,7 @@
     "eval_credentials": "",
     "tags": [
         "Asana",
+        "Tasks",
         "Internal"
     ]
 }

--- a/SearchProviders/atlassian.json
+++ b/SearchProviders/atlassian.json
@@ -20,6 +20,8 @@
         "results_per_query": 10,
         "credentials": "HTTPBasicAuth('<your-username>','<your-atlassian-token>')",
         "tags": [
+            "Jira",
+            "Issues",
             "Atlassian",
             "Dev"
         ]
@@ -45,6 +47,7 @@
         "results_per_query": 10,
         "credentials": "HTTPBasicAuth('<your-username>','<your-atlassian-token>')",
         "tags": [
+            "Confluence",
             "Atlassian",
             "Dev"
         ]
@@ -77,6 +80,8 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
+            "Trello",
+            "Cards",
             "Atlassian",
             "Internal"
         ]

--- a/SearchProviders/blockchain-bitcoin.json
+++ b/SearchProviders/blockchain-bitcoin.json
@@ -27,6 +27,8 @@
         "eval_credentials": "",
         "tags": [
             "Blockchain",
+            "Bitcoin",
+            "HashID",
             "Public"
         ]
     },
@@ -58,6 +60,8 @@
         "eval_credentials": "",
         "tags": [
             "Blockchain",
+            "Bitcoin",
+            "Wallet",
             "Public"
         ]
     }

--- a/SearchProviders/company_data_bigquery.json
+++ b/SearchProviders/company_data_bigquery.json
@@ -26,6 +26,8 @@
     "eval_credentials": "",
     "tags": [
         "Google",
+        "BigQuery",
+        "Company",
         "Internal"
     ]
 }

--- a/SearchProviders/company_snowflake.json
+++ b/SearchProviders/company_snowflake.json
@@ -24,6 +24,7 @@
     "eval_credentials": "",
     "tags": [
         "Snowflake",
+        "Company",
         "Internal"
     ]
 }

--- a/SearchProviders/crunchbase.json
+++ b/SearchProviders/crunchbase.json
@@ -56,6 +56,8 @@
     "eval_credentials": "",
     "tags": [
         "Crunchbase",
+        "Organizations",
+        "Company",
         "Internal"
     ]
 }

--- a/SearchProviders/elasticsearch.json
+++ b/SearchProviders/elasticsearch.json
@@ -18,6 +18,9 @@
     "results_per_query": 10,
     "credentials": "verify_certs=[True|False],ca_certs=<path-to-cert-file>,<elastic-username>:<elastic-password>",
     "tags": [
+        "Elastic",
+        "Email",
+        "Enron",
         "Internal"
     ]
 }

--- a/SearchProviders/europe_pmc.json
+++ b/SearchProviders/europe_pmc.json
@@ -29,8 +29,11 @@
     "credentials": "",
     "eval_credentials": "",
     "tags": [
-        "Public",
+        "EuropePMC",
+        "EPMC",
+        "Articles",
         "STM",
+        "Public",
         "RAG-ready"
     ]
 }

--- a/SearchProviders/funding_db_sqlite3.json
+++ b/SearchProviders/funding_db_sqlite3.json
@@ -18,6 +18,8 @@
     "results_per_query": 10,
     "credentials": "",
     "tags": [
+        "SQLite3",
+        "Company",
         "Internal"
     ]
 }

--- a/SearchProviders/gen_ai.json
+++ b/SearchProviders/gen_ai.json
@@ -18,6 +18,8 @@
     "results_per_query": 10,
     "credentials": "<your-openai-API-key>",
     "tags": [
+        "GenAI",
+        "Question",
         "Public"
     ]
 }

--- a/SearchProviders/github.json
+++ b/SearchProviders/github.json
@@ -26,6 +26,7 @@
         "eval_credentials": "",
         "tags": [
             "GitHub",
+            "Code",
             "Dev"
         ]
     },
@@ -56,6 +57,7 @@
         "eval_credentials": "",
         "tags": [
             "GitHub",
+            "Issues",
             "Dev"
         ]
     },
@@ -86,6 +88,8 @@
         "eval_credentials": "",
         "tags": [
             "GitHub",
+            "PullRequests",
+            "PRs",
             "Dev"
         ]
     },
@@ -116,6 +120,7 @@
         "eval_credentials": "",
         "tags": [
             "GitHub",
+            "Commits",
             "Dev"
         ]
     }

--- a/SearchProviders/google.json
+++ b/SearchProviders/google.json
@@ -45,6 +45,7 @@
         "credentials": "key=<your-Google-API-key>",
         "tags": [
             "Google",
+            "Web",
             "Public"
         ]
     },
@@ -73,6 +74,8 @@
         "eval_credentials": "",
         "tags": [
             "Google",
+            "News",
+            "RSS",
             "Public",
             "RAG-ready"
         ]
@@ -154,6 +157,8 @@
         "credentials": "key=<your-Google-API-key>",
         "eval_credentials": "",
         "tags": [
+            "Swirl",
+            "Dev",
             "Public",
             "RAG-ready"
         ]

--- a/SearchProviders/hacker_news.json
+++ b/SearchProviders/hacker_news.json
@@ -23,7 +23,9 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
-            "Hacker News",
+            "HackerNews",
+            "Stories",
+            "News",
             "Dev",
             "Public"
         ]
@@ -52,7 +54,8 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
-            "Hacker News",
+            "HackerNews",
+            "Comments",
             "Dev",
             "Public"
         ]

--- a/SearchProviders/hubspot.json
+++ b/SearchProviders/hubspot.json
@@ -29,6 +29,7 @@
         "eval_credentials": "",
         "tags": [
             "HubSpot",
+            "Deal",
             "Internal"
         ]
     },
@@ -62,6 +63,7 @@
         "eval_credentials": "",
         "tags": [
             "HubSpot",
+            "Company",
             "Internal"
         ]
     },
@@ -95,6 +97,8 @@
         "eval_credentials": "",
         "tags": [
             "HubSpot",
+            "Contacts",
+            "Contact",
             "Internal"
         ]
     }

--- a/SearchProviders/internet_archive.json
+++ b/SearchProviders/internet_archive.json
@@ -25,6 +25,7 @@
     "credentials": "",
     "eval_credentials": "",
     "tags": [
+        "Web",
         "Public",
         "RAG-ready"
     ]

--- a/SearchProviders/little_sis.json
+++ b/SearchProviders/little_sis.json
@@ -24,6 +24,7 @@
     "eval_credentials": "",
     "tags": [
         "LittleSis",
+        "Entities",
         "Public"
     ]
 }

--- a/SearchProviders/microsoft.json
+++ b/SearchProviders/microsoft.json
@@ -26,6 +26,9 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "Email",
+            "Microsoft",
+            "Outlook",
             "Internal"
         ]
     },
@@ -56,6 +59,9 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "Calendar",
+            "Microsoft",
+            "Outlook",
             "Internal"
         ]
     },
@@ -84,6 +90,8 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "OneDrive",
+            "Microsoft",
             "Internal"
         ]
     },
@@ -112,6 +120,8 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "SharePoint",
+            "Microsoft",
             "Internal"
         ]
     },
@@ -140,6 +150,8 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "Teams",
+            "Microsoft",
             "Internal"
         ]
     }

--- a/SearchProviders/miro.json
+++ b/SearchProviders/miro.json
@@ -18,6 +18,8 @@
     "results_per_query": 10,
     "credentials": "bearer=your-Miro-api-token",
     "tags": [
+        "Miro",
+        "Drawings",
         "Internal"
     ]
 }

--- a/SearchProviders/movies_mongodb.json
+++ b/SearchProviders/movies_mongodb.json
@@ -30,6 +30,7 @@
     "eval_credentials": "",
     "tags": [
         "MongoDB",
+        "Movies",
         "Internal"
     ]
 }

--- a/SearchProviders/open_sanctions.json
+++ b/SearchProviders/open_sanctions.json
@@ -26,6 +26,7 @@
     "eval_credentials": "",
     "tags": [
         "OpenSanctions",
+        "Entities",
         "Public"
     ]
 }

--- a/SearchProviders/opensearch.json
+++ b/SearchProviders/opensearch.json
@@ -18,6 +18,9 @@
     "results_per_query": 10,
     "credentials": "verify_certs=[True|False],ca_certs=<path-to-cert-file>,<opensearch-username>:<opensearch-password>",
     "tags": [
+        "OpenSearch",
+        "Email",
+        "Enron",
         "Internal"
     ]
 }

--- a/SearchProviders/preloaded.json
+++ b/SearchProviders/preloaded.json
@@ -45,6 +45,7 @@
         "credentials": "key=<your-Google-API-key>",
         "tags": [
             "Google",
+            "Web",
             "Public"
         ]
     },
@@ -73,6 +74,8 @@
         "eval_credentials": "",
         "tags": [
             "Google",
+            "News",
+            "RSS",
             "Public",
             "RAG-ready"
         ]
@@ -124,6 +127,8 @@
         "credentials": "key=<your-Google-API-key>",
         "eval_credentials": "",
         "tags": [
+            "Swirl",
+            "Dev",
             "Public",
             "RAG-ready"
         ]
@@ -155,6 +160,7 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
+            "Web",
             "Public",
             "RAG-ready"
         ]
@@ -190,8 +196,11 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
-            "Public",
+            "EuropePMC",
+            "EPMC",
+            "Articles",
             "STM",
+            "Public",
             "RAG-ready"
         ]
     },
@@ -219,8 +228,10 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
-            "Public",
+            "arXiv",
+            "Articles",
             "STM",
+            "Public",
             "RAG-ready"
         ]
     },
@@ -244,6 +255,8 @@
         "results_per_query": 10,
         "credentials": "<your-openai-API-key>",
         "tags": [
+            "GenAI",
+            "Question",
             "Public"
         ]
     },
@@ -267,6 +280,8 @@
         "results_per_query": 10,
         "credentials": "bearer=your-Miro-api-token",
         "tags": [
+            "Miro",
+            "Drawings",
             "Internal"
         ]
     },
@@ -298,6 +313,8 @@
         "eval_credentials": "",
         "tags": [
             "Google",
+            "BigQuery",
+            "Company",
             "Internal"
         ]
     },
@@ -321,6 +338,8 @@
         "results_per_query": 10,
         "credentials": "",
         "tags": [
+            "SQLite3",
+            "Company",
             "Internal"
         ]
     },
@@ -344,6 +363,8 @@
         "results_per_query": 10,
         "credentials": "HTTPBasicAuth('<solr-username>','<solr-password>')",
         "tags": [
+            "Solr",
+            "TechProducts",
             "Internal"
         ]
     },
@@ -367,6 +388,9 @@
         "results_per_query": 10,
         "credentials": "verify_certs=[True|False],ca_certs=<path-to-cert-file>,<opensearch-username>:<opensearch-password>",
         "tags": [
+            "OpenSearch",
+            "Email",
+            "Enron",
             "Internal"
         ]
     },
@@ -390,6 +414,9 @@
         "results_per_query": 10,
         "credentials": "verify_certs=[True|False],ca_certs=<path-to-cert-file>,<elastic-username>:<elastic-password>",
         "tags": [
+            "Elastic",
+            "Email",
+            "Enron",
             "Internal"
         ]
     },
@@ -415,6 +442,8 @@
         "results_per_query": 10,
         "credentials": "bearer=your-youtrack-permanent-token",
         "tags": [
+            "YouTrack",
+            "Articles",
             "JetBrains",
             "Dev"
         ]
@@ -441,6 +470,8 @@
         "results_per_query": 10,
         "credentials": "bearer=your-youtrack-permanent-token",
         "tags": [
+            "YouTrack",
+            "Issues",
             "JetBrains",
             "Dev"
         ]
@@ -466,6 +497,7 @@
         "results_per_query": 10,
         "credentials": "HTTPBasicAuth('<your-username>','<your-atlassian-token>')",
         "tags": [
+            "Confluence",
             "Atlassian",
             "Dev"
         ]
@@ -491,6 +523,8 @@
         "results_per_query": 10,
         "credentials": "HTTPBasicAuth('<your-username>','<your-atlassian-token>')",
         "tags": [
+            "Jira",
+            "Issues",
             "Atlassian",
             "Dev"
         ]
@@ -522,6 +556,9 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "Email",
+            "Microsoft",
+            "Outlook",
             "Internal"
         ]
     },
@@ -552,6 +589,9 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "Calendar",
+            "Microsoft",
+            "Outlook",
             "Internal"
         ]
     },
@@ -580,6 +620,8 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "OneDrive",
+            "Microsoft",
             "Internal"
         ]
     },
@@ -608,6 +650,8 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "SharePoint",
+            "Microsoft",
             "Internal"
         ]
     },
@@ -636,6 +680,8 @@
         "eval_credentials": "",
         "tags": [
             "M365",
+            "Teams",
+            "Microsoft",
             "Internal"
         ]
     },
@@ -666,6 +712,7 @@
         "eval_credentials": "",
         "tags": [
             "GitHub",
+            "Code",
             "Dev"
         ]
     },
@@ -696,6 +743,7 @@
         "eval_credentials": "",
         "tags": [
             "GitHub",
+            "Issues",
             "Dev"
         ]
     },
@@ -726,6 +774,8 @@
         "eval_credentials": "",
         "tags": [
             "GitHub",
+            "PullRequests",
+            "PRs",
             "Dev"
         ]
     },
@@ -756,6 +806,7 @@
         "eval_credentials": "",
         "tags": [
             "GitHub",
+            "Commits",
             "Dev"
         ]
     },
@@ -789,6 +840,7 @@
         "eval_credentials": "",
         "tags": [
             "HubSpot",
+            "Deal",
             "Internal"
         ]
     },
@@ -822,6 +874,7 @@
         "eval_credentials": "",
         "tags": [
             "HubSpot",
+            "Company",
             "Internal"
         ]
     },
@@ -855,6 +908,8 @@
         "eval_credentials": "",
         "tags": [
             "HubSpot",
+            "Contacts",
+            "Contact",
             "Internal"
         ]
     },
@@ -882,7 +937,9 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
-            "Hacker News",
+            "HackerNews",
+            "Stories",
+            "News",
             "Dev",
             "Public"
         ]
@@ -911,7 +968,8 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
-            "Hacker News",
+            "HackerNews",
+            "Comments",
             "Dev",
             "Public"
         ]
@@ -943,6 +1001,8 @@
         "eval_credentials": "",
         "tags": [
             "ServiceNow",
+            "Knowledge",
+            "Articles",
             "Internal"
         ]
     },
@@ -973,6 +1033,8 @@
         "eval_credentials": "",
         "tags": [
             "ServiceNow",
+            "ServiceCatalog",
+            "Items",
             "Internal"
         ]
     },
@@ -1034,6 +1096,8 @@
         "eval_credentials": "",
         "tags": [
             "Crunchbase",
+            "Organizations",
+            "Company",
             "Internal"
         ]
     },
@@ -1065,6 +1129,8 @@
         "eval_credentials": "",
         "tags": [
             "Blockchain",
+            "Bitcoin",
+            "HashID",
             "Public"
         ]
     },
@@ -1096,6 +1162,8 @@
         "eval_credentials": "",
         "tags": [
             "Blockchain",
+            "Bitcoin",
+            "Wallet",
             "Public"
         ]
     },
@@ -1127,6 +1195,8 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
+            "Trello",
+            "Cards",
             "Atlassian",
             "Internal"
         ]
@@ -1160,6 +1230,7 @@
         "eval_credentials": "",
         "tags": [
             "Asana",
+            "Tasks",
             "Internal"
         ]
     },
@@ -1195,6 +1266,7 @@
         "eval_credentials": "",
         "tags": [
             "MongoDB",
+            "Movies",
             "Internal"
         ]
     },
@@ -1224,6 +1296,7 @@
         "eval_credentials": "",
         "tags": [
             "Snowflake",
+            "Company",
             "Internal"
         ]
     },
@@ -1253,6 +1326,7 @@
         "eval_credentials": "",
         "tags": [
             "LittleSis",
+            "Entities",
             "Public"
         ]
     },
@@ -1284,6 +1358,7 @@
         "eval_credentials": "",
         "tags": [
             "OpenSanctions",
+            "Entities",
             "Public"
         ]
     },
@@ -1420,7 +1495,7 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
-            "National Archives",
+            "NationalArchives",
             "Legal",
             "Public"
         ]

--- a/SearchProviders/servicenow.json
+++ b/SearchProviders/servicenow.json
@@ -26,6 +26,8 @@
         "eval_credentials": "",
         "tags": [
             "ServiceNow",
+            "Knowledge",
+            "Articles",
             "Internal"
         ]
     },
@@ -56,6 +58,8 @@
         "eval_credentials": "",
         "tags": [
             "ServiceNow",
+            "ServiceCatalog",
+            "Items",
             "Internal"
         ]
     }

--- a/SearchProviders/solr.json
+++ b/SearchProviders/solr.json
@@ -18,6 +18,8 @@
     "results_per_query": 10,
     "credentials": "HTTPBasicAuth('<solr-username>','<solr-password>')",
     "tags": [
+        "Solr",
+        "TechProducts",
         "Internal"
     ]
 }

--- a/SearchProviders/solr_with_auth.json
+++ b/SearchProviders/solr_with_auth.json
@@ -18,6 +18,8 @@
     "results_per_query": 10,
     "credentials": "HTTPBasicAuth('<solr-username>','<solr-password>')",
     "tags": [
+        "Solr",
+        "TechProducts",
         "Internal"
     ]
 }

--- a/SearchProviders/youtrack.json
+++ b/SearchProviders/youtrack.json
@@ -21,6 +21,8 @@
         "results_per_query": 10,
         "credentials": "bearer=your-youtrack-permanent-token",
         "tags": [
+            "YouTrack",
+            "Issues",
             "JetBrains",
             "Dev"
         ]
@@ -47,6 +49,8 @@
         "results_per_query": 10,
         "credentials": "bearer=your-youtrack-permanent-token",
         "tags": [
+            "YouTrack",
+            "Articles",
             "JetBrains",
             "Dev"
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
The earlier rename PR dropped tags like Code, Issues, PRs, Commits, HashID, Wallet, Cards, YouTrack, EuropePMC, EPMC, Trello, etc. on the theory that they duplicated the left token of the name and were thus redundant. That theory was wrong: those tags back SWIRL's URL '<tag>:<query>' syntax via select_providers (utils.py:274), which matches case-insensitively against the SP tag list. The QA suite exercises this with queries like 'Code:relevancy', 'HashID:b6f6...', 'EPMC:Risks', 'Trello:conference', 'YouTrack:devops', etc. Without the tags, those queries fall through to the default sources and the test scenarios fail because results come back from News - Google News instead of the expected provider.

Restore the source-slug and content-type tags on every SP, on top of the audience tags (Internal/Public/Dev/STM/Legal/RAG-ready) and vendor tags (Google/M365/GitHub/Atlassian/HubSpot/...) that the earlier rewrite added. Galaxy chips can dedupe display-side if they want to — the source of truth is the backend tag list, and the backend needs the full set to keep tag-prefix queries working.

Notably restored:
  - Code, Issues, PRs, PullRequests, Commits on GitHub providers
  - HashID on Transactions - Blockchain; Wallet on Wallets - Blockchain
  - Cards on Tasks - Atlassian Trello
  - YouTrack on JetBrains YouTrack providers
  - EPMC, EuropePMC, Articles, STM on Articles - EuropePMC
  - arXiv, Articles, STM on Articles - arXiv
  - Microsoft + per-app slugs (Outlook/Calendar/OneDrive/SharePoint/Teams) on the M365 family (M365 tag also kept for chip grouping)
  - Swirl on Docs - SWIRL for 'Swirl:' tag-prefix queries
  - Bitcoin, HackerNews, Confluence, Jira, ServiceCatalog, etc.

Per-provider fixtures synced to match.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
