### PR TITLE
Drop 'Web' tag from Internet Archive, restore 'InternetArchive'

### DIFF
--- a/SearchProviders/internet_archive.json
+++ b/SearchProviders/internet_archive.json
@@ -25,7 +25,7 @@
     "credentials": "",
     "eval_credentials": "",
     "tags": [
-        "Web",
+        "InternetArchive",
         "Public",
         "RAG-ready"
     ]

--- a/SearchProviders/preloaded.json
+++ b/SearchProviders/preloaded.json
@@ -160,7 +160,7 @@
         "credentials": "",
         "eval_credentials": "",
         "tags": [
-            "Web",
+            "InternetArchive",
             "Public",
             "RAG-ready"
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->

The QA NOT-function scenario (search.feature:45) hit "Could not find valid NOT transformation" because adding 'Web' as a tag on Web - Internet Archive made the 'web:Elon NOT Twitter' query route to both Google PSE *and* Internet Archive. Google PSE's query_mappings has NOT_CHAR=- so the NOT is transformed correctly, but Internet Archive's mappings (NOT=true) keep the literal "NOT" in the query_to_provider URL — which the assertion flags.

Internet Archive is a curated archive, not a general web crawler, and its original tag set was ['InternetArchive']. Restoring that so web:-prefix queries only route to the actual web search engine.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
