### PR TITLE
ci: attach SBOM + provenance attestation to swirl-search docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -61,9 +61,16 @@ jobs:
           TAG_NAME=$([ "$BRANCH_NAME" = "main" ] && echo "latest" || echo "$BRANCH_NAME")
           echo "Building tag: swirlai/swirl-search:$TAG_NAME"
           docker buildx use devBuilder || docker buildx create --name devBuilder --use
+          # --sbom=true + --provenance=mode=max attach an SBOM (SPDX) and a
+          # max-detail SLSA provenance attestation to every published image
+          # as a multi-arch manifest attestation. Customers can fetch via:
+          #   docker buildx imagetools inspect swirlai/swirl-search:latest \
+          #     --format '{{ json .SBOM }}'
           docker buildx build \
             -t swirlai/swirl-search:$TAG_NAME \
             --platform linux/amd64,linux/arm64 \
+            --sbom=true \
+            --provenance=mode=max \
             --push .
 
       - name: Update the Docker Repo Description


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
Adds --sbom=true + --provenance=mode=max to the docker buildx build invocation in .github/workflows/docker-image.yml. Every published swirlai/swirl-search image (:latest, :develop, branch tags) now ships with its own Software Bill of Materials (SPDX format) and max-detail SLSA provenance attestation as a multi-arch manifest attestation.

Why:
- Customers + enterprise procurement increasingly require an SBOM as a release artifact (US Executive Order 14028, regulated industries).
- The 4.5.0.1 CVE scramble would have been a 5-second SBOM grep instead of a manual scan of every Layer-16 package version.
- Docker Hub displays SBOM + provenance natively; no UI work needed.

Customer fetch:
  docker buildx imagetools inspect swirlai/swirl-search:latest \ --format '{{ json .SBOM }}' docker buildx imagetools inspect swirlai/swirl-search:latest \ --format '{{ json .Provenance }}'

No release impact: attestations are added on the next docker-image build, no source code changed. The next swirl-search :latest publish (via test-build-pipeline on main OR manual workflow_dispatch) carries the first attestations.

Sibling PR on swirl-galaxy-ui:
  https://github.com/swirlai/swirl-galaxy-ui/pull/new/ci/add-sbom-provenance

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [X] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
