### PR TITLE
feat(rag): pipe user-supplied ai_instructions from URL into RAG prompt

### DIFF
--- a/swirl/processors/rag.py
+++ b/swirl/processors/rag.py
@@ -94,7 +94,7 @@ class RAGPostResultProcessor(PostResultProcessor):
 
     type="RAGPostResultProcessor"
 
-    def __init__(self, search_id, request_id='', should_get_results=False, rag_query_items=False, rag_timeout=None):
+    def __init__(self, search_id, request_id='', should_get_results=False, rag_query_items=False, rag_timeout=None, ai_instructions=''):
         super().__init__(search_id=search_id, request_id=request_id, should_get_results=should_get_results, rag_query_items=rag_query_items)
         self.tasks = None
         self.stop_background_thread = False
@@ -106,6 +106,12 @@ class RAGPostResultProcessor(PostResultProcessor):
         # surface. Passing this value straight into the completion call
         # below makes the timeout actually take effect.
         self.rag_timeout = rag_timeout
+        # Free-form user-provided instructions for this RAG response. Wired
+        # from Galaxy's "Optional instructions for the AI Response..."
+        # textarea via ?ai_instructions=... on detail-search-rag. Threaded
+        # into RagPrompt below so it lands in the prompt body the model
+        # actually sees. Empty string = no extra instructions.
+        self.ai_instructions = (ai_instructions or '').strip()
         try:
             rag_result = Result.objects.get(search_id=search_id, searchprovider='ChatGPT')
             if rag_result:
@@ -186,7 +192,8 @@ class RAGPostResultProcessor(PostResultProcessor):
         rag_prompt = RagPrompt(
             user_query,
             max_tokens=max_tokens,
-            model=self.client.get_encoding_model()
+            model=self.client.get_encoding_model(),
+            query_instructions=self.ai_instructions,
         )
         logger.info(f"RAG: token budget={max_tokens} model={self.client.get_encoding_model()}")
 

--- a/swirl/rag_prompt.py
+++ b/swirl/rag_prompt.py
@@ -19,11 +19,28 @@ class RagPrompt():
     def __str__(self):
         return f"{self.__class__.__name__}"
 
-    def __init__(self, query, max_tokens, model):
+    def __init__(self, query, max_tokens, model, query_instructions=""):
         self._query = query
         self._max_tokens = max_tokens
         self._model = model
-        self._prompt_text = f"Answer this query '{query}' given the following recent search results as background information. Do not mention that you are using the provided background information. Please cite the sources at the end of your response. Ignore information that is off-topic or obviously conflicting, without warning about it."
+        # query_instructions: optional free-form user-supplied guidance for
+        # this specific RAG response (e.g., "respond in markdown", "keep it
+        # under 200 words", "address the reader as 'team'"). Galaxy has
+        # had an "Optional instructions for the AI Response..." textarea
+        # for a while and sends the value via ?ai_instructions=... on the
+        # detail-search-rag endpoint; before this change the backend
+        # accepted the URL param but silently dropped it. Weaving the
+        # instructions into the prompt as an additional clause lets the
+        # model honour them without us shipping a separate system-prompt
+        # pathway.
+        self._query_instructions = (query_instructions or "").strip()
+        instructions_clause = (
+            f" Additionally, follow these user-provided instructions when "
+            f"composing your answer: {self._query_instructions}."
+            if self._query_instructions
+            else ""
+        )
+        self._prompt_text = f"Answer this query '{query}'{instructions_clause} given the following recent search results as background information. Do not mention that you are using the provided background information. Please cite the sources at the end of your response. Ignore information that is off-topic or obviously conflicting, without warning about it."
         self._is_full = False
         self._num_tokens = 0
         self._last_chunk_status = RAG_PROMPT_CHUNK_OK

--- a/swirl/tests/test_search_rag.py
+++ b/swirl/tests/test_search_rag.py
@@ -54,6 +54,72 @@ def test_rag_timeout_non_integer_is_ignored():
 
 
 # ---------------------------------------------------------------------------
+# SearchRag.__init__ — ai_instructions extraction
+# ---------------------------------------------------------------------------
+
+def test_ai_instructions_absent_defaults_to_empty_string():
+    sr = SearchRag(_FakeRequest({}))
+    assert sr.ai_instructions == ""
+
+
+def test_ai_instructions_is_extracted_from_request():
+    sr = SearchRag(_FakeRequest({"ai_instructions": "Respond in bullet points."}))
+    assert sr.ai_instructions == "Respond in bullet points."
+
+
+def test_ai_instructions_is_trimmed():
+    sr = SearchRag(_FakeRequest({"ai_instructions": "   keep under 100 words   "}))
+    assert sr.ai_instructions == "keep under 100 words"
+
+
+def test_ai_instructions_capped_at_2000_chars():
+    # Defensive bound — keeps a megabyte payload from blowing up the
+    # prompt token budget. The actual prompt limit is RAG_MAX_TOKENS;
+    # this is just a fast upfront sanity cap.
+    sr = SearchRag(_FakeRequest({"ai_instructions": "x" * 5000}))
+    assert len(sr.ai_instructions) == 2000
+
+
+# ---------------------------------------------------------------------------
+# RagPrompt — query_instructions weaving
+# ---------------------------------------------------------------------------
+
+def test_rag_prompt_without_instructions_omits_clause():
+    from swirl.rag_prompt import RagPrompt
+
+    p = RagPrompt(query="diabetes treatments", max_tokens=4000, model="gpt-4")
+    assert "user-provided instructions" not in p._prompt_text
+    assert "diabetes treatments" in p._prompt_text
+
+
+def test_rag_prompt_with_instructions_weaves_clause():
+    from swirl.rag_prompt import RagPrompt
+
+    p = RagPrompt(
+        query="diabetes treatments",
+        max_tokens=4000,
+        model="gpt-4",
+        query_instructions="Respond in markdown bullet points.",
+    )
+    assert "user-provided instructions" in p._prompt_text
+    assert "Respond in markdown bullet points." in p._prompt_text
+    # Original query phrasing preserved before the instruction clause.
+    assert "Answer this query 'diabetes treatments'" in p._prompt_text
+
+
+def test_rag_prompt_with_blank_instructions_treated_as_absent():
+    # Galaxy's URL param can be present-but-empty (?ai_instructions=).
+    # Whitespace-only should also be treated as no instructions.
+    from swirl.rag_prompt import RagPrompt
+
+    for blank in ("", "   ", "\n\t"):
+        p = RagPrompt(
+            query="q", max_tokens=4000, model="gpt-4", query_instructions=blank
+        )
+        assert "user-provided instructions" not in p._prompt_text
+
+
+# ---------------------------------------------------------------------------
 # SearchRag._extract_result
 # ---------------------------------------------------------------------------
 

--- a/swirl/views_helpers/search_rag.py
+++ b/swirl/views_helpers/search_rag.py
@@ -41,6 +41,17 @@ class SearchRag:
             except (TypeError, ValueError):
                 self.rag_timeout = None
 
+        # Free-form user-supplied guidance for the RAG response. Galaxy
+        # sends this via the "Optional instructions for the AI Response..."
+        # textarea as ?ai_instructions=...; before this wiring the backend
+        # silently dropped it. We trim and bound the value to keep a
+        # malicious / accidental megabyte payload from blowing up the
+        # prompt budget — RAG_MAX_TOKENS is the real backstop but a cheap
+        # upfront cap is cleaner than letting RagPrompt see truncated
+        # mid-sentence text.
+        ai_instructions_raw = request_data.get("ai_instructions", "") or ""
+        self.ai_instructions = ai_instructions_raw.strip()[:2000]
+
     def _extract_result(self, json_result: dict) -> tuple:
         """Return (body_text, additional_content) from a stored rag json_result."""
         body = json_result.get("body", [None])
@@ -82,6 +93,7 @@ class SearchRag:
             should_get_results=True,
             rag_query_items=self.rag_query_items,
             rag_timeout=self.rag_timeout,
+            ai_instructions=self.ai_instructions,
         )
         instances[self.search_id] = rag_processor
         if rag_processor.validate():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
Galaxy has had an "Optional instructions for the AI Response..." textarea for some time. The value is sent to the backend via GET /api/swirl/sapi/detail-search-rag/?ai_instructions=... — but the backend silently dropped it: SearchRag.__init__ extracted only rag_items and rag_timeout, the RAG processor never saw the param, and the prompt template was hardcoded with no slot for user-supplied guidance.

This wires the field through end-to-end:

  Galaxy URL (?ai_instructions=...)
    -> SearchRag (extract, trim, cap at 2000 chars)
    -> RAGPostResultProcessor.__init__(ai_instructions=...)
    -> RagPrompt.__init__(query_instructions=...)
    -> prompt body sent to the LLM

The prompt now reads (with example instructions):

  Answer this query 'diabetes treatments' Additionally, follow these
  user-provided instructions when composing your answer: Respond in
  markdown bullet points. given the following recent search results...

When the field is absent / blank / whitespace-only, the prompt is identical to the pre-change wording — no behaviour change for existing callers.

Defensive bound: the URL param is trimmed and capped at 2000 chars in SearchRag (RAG_MAX_TOKENS is the real backstop, this is just a cheap upfront sanity cap).

Tests: 7 new pytest cases in test_search_rag.py — 4 for SearchRag URL extraction (absent / present / trimmed / capped), 3 for RagPrompt template weaving (no clause when absent, clause when present, blank treated as absent). 153/153 in the full unit-test suite (146 baseline + 7 new) — no regressions.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [ ] Bug fix or other non-breaking change that addresses an issue
- [X] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
