### PR TITLE
fix(SearchViewSet): put TokenAuthentication first to bypass CSRF on DELETE

### DIFF
--- a/swirl/views.py
+++ b/swirl/views.py
@@ -514,7 +514,15 @@ class SearchViewSet(viewsets.ModelViewSet):
     """
     queryset = Search.objects.all()
     serializer_class = SearchSerializer
-    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
+    # TokenAuthentication first: when Galaxy sends `Authorization: Token <key>`
+    # alongside a stale session cookie, SessionAuthentication-first caused
+    # DRF to authenticate via the session and then enforce CSRF on unsafe
+    # methods (DELETE / PUT / POST). Without a fresh csrftoken cookie that
+    # matched the X-CSRFToken header, every search-history delete returned
+    # 403, and the Galaxy auth-interceptor over-reacted by clearing
+    # localStorage — appearing to log the user out and wipe their history.
+    # Putting Token first lets the explicit Token header win cleanly.
+    authentication_classes = [TokenAuthentication, SessionAuthentication, BasicAuthentication]
 
     def report(self):
         return self.queryset


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the TITLE above -->

## Branching Reminders
- For core code changes, create a branch off `develop`
- For product documentation changes, create a branch off `main` 
- Always name your branch in a way that clearly describes your proposed changes

## Description
<!--- Describe in detail the work in this PR. -->
Galaxy's search-history "delete row" handler sends:
  DELETE /api/swirl/sapi/search/<id>/
  Authorization: Token <key>
  X-CSRFToken: <csrf>

The Galaxy session also carries a sessionid cookie because the user authenticated via the form login. DRF iterates authentication_classes in order; with SessionAuthentication listed first, the session cookie won the race and SessionAuthentication's enforce_csrf() ran on this unsafe method. Any mismatch or missing csrftoken cookie (common with SPAs that have been open across server restarts) produced a 403 — and the explicit Token header never got a chance to authenticate.

The Galaxy auth-interceptor over-reacted to the 403 by wiping localStorage, which surfaced to the user as:

  1. The search-history list appeared to clear
  2. The next page reload logged them out
  3. The original row was never deleted

That interceptor over-reaction is being fixed separately on the Galaxy side. The root cause — Token auth losing to Session auth + CSRF check — is fixed here by reordering authentication_classes so TokenAuthentication runs first. When the request carries `Authorization: Token <key>` the token auth wins cleanly with no CSRF check. When there is no Token header (e.g. Django's browsable API used by an admin who is logged into the Django session), DRF falls through to SessionAuthentication exactly as before.

No QA test changes needed — the QA suite already uses Token auth, and the session-auth path stays available for unauthenticated browser sessions hitting the browsable API.

## Related Issue(s)
<!--- If this PR addresses any open Issues, please link to them. -->


## Testing and Validation
<!--- Please describe in detail how you tested this PR. -->


## Type of Change
<!-- Check all that apply to this PR. -->
- [X] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
