### PR TITLE
fix(auth): OptionalTokenAuthentication — fall through on invalid token

### DIFF
--- a/swirl/authentication.py
+++ b/swirl/authentication.py
@@ -1,0 +1,57 @@
+"""
+Custom Django REST Framework authentication classes for SWIRL.
+"""
+
+from rest_framework import exceptions
+from rest_framework.authentication import TokenAuthentication
+
+
+class OptionalTokenAuthentication(TokenAuthentication):
+    """
+    A TokenAuthentication variant that returns ``None`` instead of raising
+    ``AuthenticationFailed`` when an ``Authorization: Token <key>`` header
+    is present but the key is unknown / inactive / malformed.
+
+    Why this exists
+    ---------------
+    Stock ``rest_framework.authentication.TokenAuthentication`` raises
+    ``AuthenticationFailed`` as soon as it sees an Authorization header
+    that *looks* like Token auth but doesn't validate. DRF's auth chain
+    treats that as a hard 401 — subsequent authentication classes in the
+    viewset's ``authentication_classes`` list never get a chance.
+
+    For viewsets that legitimately accept BOTH Token and Session auth
+    (e.g. anything Galaxy can call), this is a problem: Galaxy stores
+    its API token in localStorage and attaches it to every request, but
+    the same browser also carries a Django session cookie set during
+    form login. If the localStorage token is stale (expired, revoked,
+    or carried over from a previous login in the same Selenium session)
+    while the session cookie is still valid, the stock behaviour is:
+
+        TokenAuthentication.authenticate() raises -> DRF returns 401
+        SessionAuthentication.authenticate() never runs
+
+    This class makes that case fall through instead — the request gets
+    a chance to authenticate via the session cookie. Concrete impact:
+    the SWIRL search-history delete flow used to round-trip a 403 (from
+    CSRF on SessionAuth) and the Galaxy interceptor over-reacted by
+    clearing localStorage. The original fix put Token auth first to
+    bypass CSRF on safe-Token requests, but that exposed the
+    stale-Token-but-valid-session 401 documented above. This class
+    resolves both: Token wins when valid; Session is tried when Token
+    is invalid.
+
+    Security note
+    -------------
+    A bogus Token header from an unauthenticated client now returns 401
+    via the BasicAuth/SessionAuth tail of the chain rather than the more
+    specific "Invalid token" message TokenAuthentication would have
+    produced. That is intentional — the failure mode is the same (401)
+    and the diagnostic difference doesn't aid an attacker.
+    """
+
+    def authenticate(self, request):
+        try:
+            return super().authenticate(request)
+        except exceptions.AuthenticationFailed:
+            return None

--- a/swirl/tests/test_authentication.py
+++ b/swirl/tests/test_authentication.py
@@ -1,0 +1,173 @@
+"""
+Unit + integration tests for swirl.authentication.OptionalTokenAuthentication.
+
+The unit tests exercise the class in isolation.
+
+The integration tests against SearchViewSet are the regression coverage for
+4.5.0.3: that release reordered SearchViewSet's authentication_classes to put
+stock TokenAuthentication first, which short-circuited the auth chain when the
+client sent an invalid/stale Token header alongside a valid session cookie —
+exactly the state Selenium / Galaxy ends up in across qa-suite scenarios.
+qa-suite caught it (~50 min into the run); this test catches it in unit-tests
+(seconds).
+
+Run with:  pytest swirl/tests/test_authentication.py -v
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import RequestFactory
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from swirl.authentication import OptionalTokenAuthentication
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def user(db):
+    # Superuser so the test bypasses SearchViewSet's per-method has_perm()
+    # checks. We're testing the auth chain, not the permission layer.
+    return User.objects.create_user(
+        username='auth_user', password='pw',
+        is_staff=True, is_superuser=True,
+    )
+
+
+@pytest.fixture
+def valid_token(db, user):
+    return Token.objects.create(user=user)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — OptionalTokenAuthentication in isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_optional_token_auth_valid_token_authenticates(user, valid_token):
+    """Valid Token header → returns (user, token) tuple (matches stock behaviour)."""
+    rf = RequestFactory()
+    req = rf.get('/api/swirl/sapi/search/', HTTP_AUTHORIZATION=f'Token {valid_token.key}')
+    result = OptionalTokenAuthentication().authenticate(req)
+    assert result is not None
+    auth_user, auth_token = result
+    assert auth_user == user
+    assert auth_token == valid_token
+
+
+@pytest.mark.django_db
+def test_optional_token_auth_invalid_token_returns_none(db):
+    """Invalid Token header → returns None (NOT raise) so the next auth class can try.
+
+    This is the behaviour that distinguishes OptionalToken from stock Token.
+    Stock TokenAuthentication raises AuthenticationFailed here, which DRF
+    converts to a hard 401 — short-circuiting the auth chain.
+    """
+    rf = RequestFactory()
+    req = rf.get('/api/swirl/sapi/search/', HTTP_AUTHORIZATION='Token nosuchtoken')
+    result = OptionalTokenAuthentication().authenticate(req)
+    assert result is None
+
+
+def test_optional_token_auth_no_header_returns_none():
+    """No Authorization header → returns None (matches stock behaviour)."""
+    rf = RequestFactory()
+    req = rf.get('/api/swirl/sapi/search/')
+    result = OptionalTokenAuthentication().authenticate(req)
+    assert result is None
+
+
+def test_optional_token_auth_non_token_header_returns_none():
+    """Authorization header that isn't Token-scheme → returns None.
+
+    Stock TokenAuthentication also returns None in this case (lets other
+    auth classes — e.g. Basic — handle their own scheme).
+    """
+    rf = RequestFactory()
+    req = rf.get('/api/swirl/sapi/search/', HTTP_AUTHORIZATION='Bearer something.jwt.shape')
+    result = OptionalTokenAuthentication().authenticate(req)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — SearchViewSet auth chain
+#
+# These tests are the explicit regression for 4.5.0.3. They drive the full
+# DRF chain (OptionalTokenAuthentication -> SessionAuthentication ->
+# BasicAuthentication) via APIClient and assert that BOTH halves of the bug
+# stay fixed simultaneously:
+#
+#   (a) Valid Token wins cleanly without CSRF enforcement on unsafe methods
+#       — this was the original DELETE-403 cascade fix.
+#   (b) Invalid Token alongside a valid session falls through and Session
+#       still authenticates — this is what regressed in 4.5.0.3 and tripped
+#       qa-suite an hour into the run.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_searchviewset_valid_token_alone_authenticates(user, valid_token):
+    """Plain Token-only auth (no session) → 200 on GET /swirl/sapi/search/.
+
+    Hits the /swirl/search/ path (not /api/swirl/sapi/search/) because the
+    sapi-prefixed path passes through swirl.middleware.TokenMiddleware,
+    which has its own auth handling; the goal of these tests is to exercise
+    DRF's authentication_classes chain on SearchViewSet directly.
+    """
+    c = APIClient()
+    c.credentials(HTTP_AUTHORIZATION=f'Token {valid_token.key}')
+    r = c.get('/swirl/search/')
+    assert r.status_code == 200, f'Token auth should succeed; got {r.status_code} body={r.content!r:.200}'
+
+
+@pytest.mark.django_db
+def test_searchviewset_session_alone_authenticates(user):
+    """Session cookie alone (no Token header) → 200. Django admin / browsable
+    API depend on this path."""
+    c = APIClient()
+    c.force_login(user)
+    r = c.get('/swirl/search/')
+    assert r.status_code == 200, f'Session auth should succeed; got {r.status_code} body={r.content!r:.200}'
+
+
+@pytest.mark.django_db
+def test_searchviewset_stale_token_plus_valid_session_authenticates(user):
+    """REGRESSION TEST FOR 4.5.0.3.
+
+    Client sends an invalid Token header (e.g. a stale value carried over
+    from a previous login) AND a valid session cookie. The session is
+    sufficient — auth must succeed.
+
+    With stock TokenAuthentication listed first (4.5.0.3 behaviour), this
+    returned 401: TokenAuthentication raised AuthenticationFailed on the
+    stale token and short-circuited the auth chain. With
+    OptionalTokenAuthentication first, the invalid token is dropped
+    silently (returns None) and SessionAuthentication picks up the session
+    cookie.
+    """
+    c = APIClient()
+    c.force_login(user)
+    c.credentials(HTTP_AUTHORIZATION='Token stale_invalid_value')
+    r = c.get('/swirl/search/')
+    assert r.status_code == 200, (
+        f'Stale-token + valid-session should still authenticate via session; '
+        f'got {r.status_code} body={r.content!r:.200}'
+    )
+
+
+@pytest.mark.django_db
+def test_searchviewset_no_credentials_is_rejected():
+    """No auth at all → 401 (DRF authentication failure) OR 403 (the
+    SearchViewSet.list() per-method has_perm check fires for the resulting
+    AnonymousUser). Sanity check that the chain still rejects anonymous
+    requests after the reorder + new auth class — we don't care which of
+    the two negative statuses comes out, just that the request is denied."""
+    c = APIClient()
+    r = c.get('/swirl/search/')
+    assert r.status_code in (401, 403), (
+        f'Anonymous request should be 401 or 403; got {r.status_code}'
+    )

--- a/swirl/views.py
+++ b/swirl/views.py
@@ -27,6 +27,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authtoken.models import Token
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
+from swirl.authentication import OptionalTokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 
 from drf_spectacular.utils import extend_schema, OpenApiParameter
@@ -514,15 +515,18 @@ class SearchViewSet(viewsets.ModelViewSet):
     """
     queryset = Search.objects.all()
     serializer_class = SearchSerializer
-    # TokenAuthentication first: when Galaxy sends `Authorization: Token <key>`
-    # alongside a stale session cookie, SessionAuthentication-first caused
-    # DRF to authenticate via the session and then enforce CSRF on unsafe
-    # methods (DELETE / PUT / POST). Without a fresh csrftoken cookie that
-    # matched the X-CSRFToken header, every search-history delete returned
-    # 403, and the Galaxy auth-interceptor over-reacted by clearing
-    # localStorage — appearing to log the user out and wipe their history.
-    # Putting Token first lets the explicit Token header win cleanly.
-    authentication_classes = [TokenAuthentication, SessionAuthentication, BasicAuthentication]
+    # OptionalTokenAuthentication FIRST so the explicit `Authorization: Token`
+    # header Galaxy sends wins cleanly when valid (bypasses CSRF enforcement
+    # on unsafe methods — the original 403 cascade on the search-history
+    # delete flow). OptionalToken differs from stock TokenAuthentication in
+    # one important way: when the token header is present but invalid (stale,
+    # revoked, or carried over from a prior login in the same Selenium /
+    # browser session), it RETURNS None instead of raising
+    # AuthenticationFailed. That hands control to SessionAuthentication,
+    # which authenticates via the session cookie set during form login.
+    # Stock TokenAuth would have short-circuited the chain at 401, which is
+    # what regressed the QA suite on 4.5.0.3.
+    authentication_classes = [OptionalTokenAuthentication, SessionAuthentication, BasicAuthentication]
 
     def report(self):
         return self.queryset


### PR DESCRIPTION
## Problem

4.5.0.3 reordered `SearchViewSet.authentication_classes` to put stock `TokenAuthentication` first, so Galaxy's explicit `Authorization: Token` header would win before `SessionAuthentication` enforced CSRF on unsafe methods (the original DELETE-403 cascade fix on search-history rows). That worked for clients that always send a valid token — but stock `TokenAuthentication` **raises** `AuthenticationFailed` when the header is present but invalid, short-circuiting DRF's auth chain. Anywhere the same client carried both a stale Token header AND a valid session cookie, the request returned 401, the Galaxy auth-interceptor called logout(), and the next page reload effectively logged the user out.

qa-suite caught this an hour into the 4.5.0.3 `test-build-pipeline` run — the same Selenium browser instance carries a stale token across scenarios and the second scenario onwards all timed out waiting for results.

## Fix

New `swirl.authentication.OptionalTokenAuthentication` subclass that swallows `AuthenticationFailed` and returns `None`, letting the next authenticator in the chain try. `SearchViewSet` now uses:

```python
authentication_classes = [OptionalTokenAuthentication, SessionAuthentication, BasicAuthentication]
```

Matrix:

| Request | Result |
|---|---|
| Valid Token header | Token wins, no CSRF check (original 4.5.0.3 fix preserved) |
| Invalid Token header + valid session cookie | **Session wins (new)** — this was 401 in 4.5.0.3 |
| Session cookie alone | Session wins, unchanged |
| No credentials | 401/403, unchanged |

## Tests

- `swirl/tests/test_authentication.py`: 4 unit tests for the class in isolation + 4 APIClient integration tests against `SearchViewSet`. The stale-token-plus-valid-session integration test would have failed in the `unit-tests` job in seconds rather than waiting an hour for qa-suite — it's the explicit regression guard for the 4.5.0.3 fault.
- Full pytest sweep: **173 passing** (165 prior + 8 new).

Safe to merge to develop; the prior 4.5.0.3 release was tagged but `:latest` was never republished (qa-suite was cancelled), so docker users are unaffected. Plan: ship the next public release as 4.5.0.4 with this fix included.