### PR TITLE
[DS-XX] Add Claude Code project guidelines and reusable workflows

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,35 @@
+# Claude Code Structure
+
+This directory defines the Claude Code operating model for this repository.
+
+## Included components
+
+| Path | Purpose |
+|---|---|
+| `agents/` | Specialized review agents |
+| `commands/` | Custom slash command prompts for common tasks |
+| `skills/` | Reusable workflows for install, DevUtils, Docker, RAG/search, and handoffs |
+| `rules/` | Repository-specific guardrails |
+| `settings.example.json` | Conservative local permission example |
+
+## Setup
+
+Copy the example settings to initialize local Claude permissions:
+
+```bash
+cp .claude/settings.example.json .claude/settings.json
+```
+
+## Recommended workflows
+
+```text
+/local-install-plan
+/devutils-script-review
+/docker-image-build-plan
+/search-provider-and-rag-review
+/context-handoff
+```
+
+## Safety posture
+
+This repository includes scripts that can mutate Docker registries, local environments, and external search indexes. Treat execution as high-risk unless the script is explicitly read-only or dry-run.

--- a/.claude/agents/devutils-reviewer.md
+++ b/.claude/agents/devutils-reviewer.md
@@ -1,0 +1,43 @@
+---
+name: devutils-reviewer
+description: Use this agent to review DevUtils scripts for purpose, safety, dependencies, mutating behavior, secrets, and correct usage.
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+You are a DevUtils script reviewer for the SWIRL community repo.
+
+Known scripts under `DevUtils/`:
+- `pre-checkin-tests.sh` — run unit and smoke tests before a PR
+- `run-integtration-tests.sh` — run integration/API tests
+- `verify_search.py` — POST to a search endpoint and verify the response
+- `clone_swirl.sh` — clone the repo using a GitHub PAT (prompts interactively; do not pass PAT on the command line)
+- `fix_csv.py` — local CSV data fix utility
+- `index_email_elastic.py` — index email data into Elasticsearch
+- `index_email_opensearch.py` — index email data into OpenSearch
+- `Swirl.postman_collection.json` — Postman collection with API examples
+
+Focus on:
+- Script purpose and expected inputs.
+- Local vs external side effects.
+- API, index, auth, or file-system impact.
+- Secrets and credential handling.
+- Safe dry-run/read-only options.
+- Correct command examples.
+
+Return:
+
+```md
+## Script review summary
+## Inputs and flags
+## Dependencies
+## External systems touched
+## Mutating behavior
+## Secrets involved
+## Safe execution recommendation
+## Approval required
+```
+
+Do not edit files. Do not print secrets.

--- a/.claude/agents/search-rag-reviewer.md
+++ b/.claude/agents/search-rag-reviewer.md
@@ -1,0 +1,33 @@
+---
+name: search-rag-reviewer
+description: Use this agent to review SearchProvider, AI Provider, Page Fetcher, Tika, RAG, provider migration, and benchmark changes.
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+You are a search and RAG configuration reviewer.
+
+Focus on:
+- SearchProvider behavior.
+- AI Provider roles, active/default settings, model IDs, and configs.
+- Page Fetcher fallback and timeout behavior.
+- Tika endpoint and MIME allowlist.
+- RAG distribution strategy and token limits.
+- API key or token exposure risk.
+- Provider migration scripts and generated JSON.
+
+Return:
+
+```md
+## Search/RAG review summary
+## Provider impact
+## RAG behavior impact
+## Page Fetcher/Tika impact
+## Secrets risk
+## Validation plan
+## Recommendation
+```
+
+Do not reveal provider API keys or bearer tokens.

--- a/.claude/agents/security-compliance-reviewer.md
+++ b/.claude/agents/security-compliance-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: security-compliance-reviewer
+description: Use this agent to review secrets, auth, API key exposure, documentation sanitization, and GitHub Actions workflow credential usage.
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+You are a security and compliance reviewer.
+
+Focus on:
+- Secret/API key leakage.
+- Personal names or personal email addresses in reusable docs.
+- OAuth/OIDC redirect and token handling.
+- Docker credentials and GitHub Actions secrets.
+- Postman collections and generated JSON.
+- `.env` values accidentally committed.
+- GitHub Actions workflow steps that log or expose secrets.
+
+Return:
+
+```md
+## Security review summary
+## Findings
+| Severity | Area | Finding | Recommendation |
+|---|---|---|---|
+## Required fixes
+## Residual risk
+```
+
+Do not print sensitive values. Use placeholders.

--- a/.claude/commands/context-handoff.md
+++ b/.claude/commands/context-handoff.md
@@ -1,0 +1,1 @@
+Use the `context-handoff` skill. Produce a compact summary preserving files, commands, impacts, risks, blockers, and next safe action without secrets.

--- a/.claude/commands/devutils-script-review.md
+++ b/.claude/commands/devutils-script-review.md
@@ -1,0 +1,1 @@
+Use the `devutils-script-review` skill. Review the target DevUtils script before recommending execution. Classify mutating behavior and secrets involved.

--- a/.claude/commands/docker-image-build-plan.md
+++ b/.claude/commands/docker-image-build-plan.md
@@ -1,0 +1,1 @@
+Use the `docker-image-build-plan` skill. Prefer dry-run first. Do not push images or print Docker credentials.

--- a/.claude/commands/local-install-plan.md
+++ b/.claude/commands/local-install-plan.md
@@ -1,0 +1,1 @@
+Use the `local-install-plan` skill. Create a safe local installation or troubleshooting plan. Do not print `.env` values or credentials.

--- a/.claude/commands/search-provider-and-rag-review.md
+++ b/.claude/commands/search-provider-and-rag-review.md
@@ -1,0 +1,1 @@
+Use the `search-provider-and-rag-review` skill. Review SearchProvider, AI Provider, Page Fetcher, Tika, and RAG changes without exposing secrets.

--- a/.claude/rules/deployment-and-infra.md
+++ b/.claude/rules/deployment-and-infra.md
@@ -1,0 +1,31 @@
+# Deployment and CI/CD Rule
+
+Apply this rule when working with GitHub Actions workflows (`.github/workflows/`), Docker build scripts, or any push/publish operation.
+
+## High-risk areas
+
+- Docker image build and push to Docker Hub.
+- GitHub Actions workflow changes that trigger on push to `main` or `develop`.
+- Secrets referenced in workflows (`SBS_DOCKER_USER`, `SBS_DOCKER_PAT`, `QA_*` secrets).
+- `db.sqlite3.dist` auto-update pipeline (modifies committed file via PR).
+
+## Rules
+
+- Do not push Docker images manually — all builds go through GitHub Actions.
+- Do not trigger `workflow_dispatch` workflows without explicit approval when they push images.
+- Do not print or log GitHub Actions secret values.
+- Review workflow trigger paths before proposing changes to `paths-ignore` filters.
+- Treat the QA suite secrets (OpenSearch/Elasticsearch credentials, API keys) as sensitive.
+
+## Required review output
+
+```md
+## Workflow/script involved
+## Trigger and conditions
+## Secrets used
+## Artifacts affected (images, db files, docs)
+## Push/publish behavior
+## Commands proposed
+## Approval required
+## Rollback notes
+```

--- a/.claude/rules/devutils.md
+++ b/.claude/rules/devutils.md
@@ -1,0 +1,33 @@
+# DevUtils Rule
+
+Apply this rule when changing or using scripts under `DevUtils/`.
+
+## Categories
+
+- Test/check-in: `pre-checkin-tests.sh`, `run-integtration-tests.sh`.
+- API/search verification: `verify_search.py`, `Swirl.postman_collection.json`.
+- Repository utility: `clone_swirl.sh`.
+- Data/indexing: `fix_csv.py`, `index_email_elastic.py`, `index_email_opensearch.py`.
+
+## Rules
+
+- Read the script before suggesting usage.
+- Identify whether the script is read-only, local-mutating, networked, or credentialed.
+- Do not run credentialed, external, or network-indexing scripts without approval.
+- Do not print arguments that contain passwords, bearer tokens, or API keys.
+- `clone_swirl.sh` prompts for a GitHub PAT interactively — do not pass the PAT on the command line.
+
+## Output requirement
+
+For any DevUtils script recommendation, provide:
+
+```md
+## Script
+## Purpose
+## Inputs required
+## External systems touched
+## Mutating behavior
+## Secrets involved
+## Safe dry-run/test option
+## Recommended command
+```

--- a/.claude/rules/search-rag.md
+++ b/.claude/rules/search-rag.md
@@ -1,0 +1,40 @@
+# Search, RAG, and Provider Configuration Rule
+
+Apply this rule when changing SearchProviders, AI Providers, Page Fetcher configuration, Tika, RAG settings, provider migration scripts, benchmark scripts, or provider JSON.
+
+## Sensitive fields
+
+Treat these as sensitive:
+
+- `api_key`
+- OAuth/OIDC client secrets
+- Provider credentials
+- Bearer tokens
+- Diffbot tokens
+- Microsoft Graph tokens
+
+## Review dimensions
+
+Check:
+
+- Provider role: `reader`, `query`, `connector`, `rag`.
+- Active/default provider behavior.
+- Model identifier and token limit compatibility.
+- Page Fetcher timeout/fallback changes.
+- Tika endpoint and MIME whitelist.
+- RAG distribution strategy.
+- Whether generated provider JSON contains secrets.
+- Whether provider changes affect public web search, enterprise search, or authenticated content.
+
+## Output format
+
+```md
+## Provider/RAG change summary
+## SearchProvider impact
+## AI Provider impact
+## Page Fetcher/Tika impact
+## Auth/token impact
+## Secret exposure risk
+## Validation plan
+## Rollback notes
+```

--- a/.claude/rules/security-and-secrets.md
+++ b/.claude/rules/security-and-secrets.md
@@ -1,0 +1,44 @@
+# Security and Secrets Rule
+
+Apply this rule when working with API keys, `.env`, OAuth/OIDC/MSAL configuration, Docker credentials, Postman collections, database credentials, or GitHub Actions secrets.
+
+## Never do
+
+- Never print real secrets, tokens, passwords, private keys, or API keys.
+- Never copy values from `.env` or Postman collections into generated docs.
+- Never replace placeholders with real secrets.
+- Never suggest committing `.env`, private keys, or credential-bearing files.
+- Never print GitHub Actions secret values from workflow output or logs.
+
+## Placeholder policy
+
+Use placeholders only:
+
+```text
+<api-key>
+<client-secret>
+<tenant-id>
+<docker-token>
+<database-password>
+<private-key>
+<github-pat>
+```
+
+## Sanitization policy
+
+When generating reusable documentation:
+
+- Remove personal names.
+- Remove personal email addresses.
+- Replace local absolute paths with generic paths.
+- Keep script filenames when needed for technical accuracy.
+
+## Review checklist
+
+Before approving changes, check:
+
+- Were any real secrets added?
+- Were any credentials moved from environment storage into Git?
+- Were auth redirect URIs, issuer URLs, or token settings changed?
+- Were GitHub Actions secrets referenced in new or changed workflow steps?
+- Were generated outputs included accidentally?

--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,0 +1,43 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(python -m compileall:*)",
+      "Bash(pytest --collect-only:*)",
+      "Bash(docker build:*)"
+    ],
+    "ask": [
+      "Bash(./install.sh:*)",
+      "Bash(./install-ui.sh:*)",
+      "Bash(./install-test.sh:*)",
+      "Bash(python swirl.py setup:*)",
+      "Bash(python swirl.py start:*)",
+      "Bash(python swirl.py stop:*)",
+      "Bash(python swirl.py restart:*)",
+      "Bash(python swirl_load.py:*)",
+      "Bash(./DevUtils/pre-checkin-tests.sh:*)",
+      "Bash(./DevUtils/run-integtration-tests.sh:*)",
+      "Bash(python ./DevUtils/verify_search.py:*)",
+      "Bash(docker buildx build:*)"
+    ],
+    "deny": [
+      "Bash(docker login:*)",
+      "Bash(docker push:*)",
+      "Bash(docker buildx build *--push*)",
+      "Bash(pg_restore:*)",
+      "Bash(psql *DROP*)",
+      "Bash(psql *TRUNCATE*)",
+      "Bash(./DevUtils/index_email_elastic.py:*)",
+      "Bash(./DevUtils/index_email_opensearch.py:*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/.env.docker)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)"
+    ]
+  }
+}

--- a/.claude/skills/context-handoff/SKILL.md
+++ b/.claude/skills/context-handoff/SKILL.md
@@ -1,0 +1,435 @@
+---
+name: context-handoff
+description: Use this skill before compacting, ending a Claude Code session, switching tasks, handing work to another engineer, or resuming work involving SWIRL installation, configuration, scripts, DevUtils, authentication, AI Providers, SearchProviders, RAG, Tika, Docker, or CI/CD workflows.
+---
+
+# Context Handoff Skill
+
+## Objective
+
+Create a compact but complete operational handoff that allows another Claude Code session or engineer to safely continue the work without losing important repository context.
+
+This repository may involve several operational domains:
+
+- Local SWIRL community installation.
+- Python/Django application setup.
+- SQLite or PostgreSQL configuration.
+- `.env` configuration.
+- OAuth/OIDC/MSAL authentication.
+- Microsoft 365 / Microsoft Graph integration.
+- SearchProvider configuration.
+- AI Provider configuration.
+- RAG behavior and distribution strategy.
+- Page Fetcher configuration.
+- Apache Tika integration.
+- DevUtils scripts.
+- Docker image build (via GitHub Actions).
+- GitHub Actions workflow changes.
+
+The handoff must preserve enough state to continue safely while avoiding secret leakage.
+
+## When to use this skill
+
+Use this skill when:
+
+- The context window is getting large.
+- `/compact` will be used.
+- A task is paused before completion.
+- Another engineer will continue the work.
+- Work is moving from investigation to implementation.
+- Work is moving from implementation to validation.
+- The task involves scripts that can mutate Docker registries, external search indexes, or OAuth providers.
+- The task involves `.env`, OIDC, OAuth, API keys, database credentials, or provider configuration.
+- The task involves SearchProvider, AI Provider, RAG, Page Fetcher, or Tika configuration.
+- The current task produced a partial plan that should not be lost.
+
+## Required safety rules
+
+Never include actual secret values in the handoff.
+
+Do not include:
+
+- API keys.
+- OAuth/OIDC client secrets.
+- Database passwords.
+- Docker registry credentials.
+- GitHub PATs or tokens.
+- Private keys.
+- Session cookies.
+- Full `.env` contents.
+- Any value that appeared in a sensitive file or command output.
+
+Use placeholders instead:
+
+```text
+<redacted>
+<stored-in-env>
+<api-key-redacted>
+<database-password-redacted>
+```
+
+If a potentially sensitive value was found, report only:
+
+```md
+Sensitive value observed: yes
+Action required: verify storage/rotation outside this handoff
+```
+
+Do not copy the value.
+
+## Handoff process
+
+Before writing the handoff:
+
+1. Identify the current goal.
+2. Identify the affected repository area.
+3. Identify files changed or inspected.
+4. Identify commands executed.
+5. Identify scripts involved.
+6. Identify whether the work is local-only or deployment/infrastructure-impacting.
+7. Identify whether any secret-bearing files were touched.
+8. Identify whether any database, Docker, or external provider action was performed or planned.
+9. Identify what was validated.
+10. Identify what remains unresolved.
+
+## Required output format
+
+Use this exact structure.
+
+```md
+## Goal
+
+Briefly describe what the session was trying to accomplish.
+
+## Current status
+
+State whether the task is:
+- Not started
+- Investigated only
+- Partially implemented
+- Implemented but not validated
+- Validated locally
+- Ready for review
+- Blocked
+
+## Repository area
+
+List the affected area(s):
+
+- Local installation
+- Python/Django app
+- `.env` / runtime config
+- SQLite / PostgreSQL / database
+- OAuth/OIDC/MSAL
+- Microsoft 365 / Microsoft Graph
+- SearchProviders
+- AI Providers
+- RAG
+- Page Fetcher
+- Apache Tika
+- DevUtils
+- Docker / GitHub Actions
+- Documentation
+- Other
+
+## Files changed
+
+List exact changed files.
+
+If no files were changed, write:
+
+No files changed.
+
+## Files inspected
+
+List important inspected files only.
+
+Do not list every file read unless it matters for continuation.
+
+## Commands run
+
+List commands that were actually run.
+
+For each command, include:
+- Working directory
+- Command
+- Result
+- Whether it was read-only or mutating
+
+Example:
+
+```text
+Working directory: .
+Command: python swirl.py config_db
+Result: not run / succeeded / failed with <summary>
+Type: mutating local database
+```
+
+## Scripts involved
+
+List any DevUtils scripts involved.
+
+For each script, include:
+- Path
+- Purpose
+- Whether it is read-only, local-mutating, infrastructure-mutating, or secret-sensitive
+- Whether it was run or only inspected
+
+Example:
+
+```text
+Path: DevUtils/example.sh
+Purpose: <summary>
+Risk: infrastructure-mutating
+Status: inspected only
+```
+
+## Decisions made
+
+List concrete decisions made during the session.
+
+## Assumptions
+
+List assumptions that were made and still need confirmation.
+
+## Installation / local runtime state
+
+Include this section when local setup was involved.
+
+Track:
+
+- Repository cloned: yes/no/unknown
+- `./install.sh`: run/not run/failed
+- `python swirl.py setup`: run/not run/failed
+- `./install-ui.sh -p`: run/not run/failed
+- `python swirl.py start`: run/not run/failed
+- Local URL: <non-sensitive URL or unknown>
+
+If not applicable, write:
+
+Not applicable.
+
+## Configuration state
+
+Include this section when `.env`, auth, provider, or runtime settings were involved.
+
+Track only non-sensitive names and placeholders.
+
+Relevant examples:
+
+- `DATABASES`: PostgreSQL / SQLite / unknown
+- `OIDC_RP_CLIENT_ID`: configured / not configured / placeholder only
+- `OIDC_RP_CLIENT_SECRET`: redacted / not inspected
+- `MS_AUTH_CLIENT_ID`: configured / not configured / placeholder only
+- `MS_TENANT_ID`: configured / not configured / placeholder only
+- `MSAL_CB_PORT`: configured / not configured / placeholder only
+- `MSAL_HOST`: configured / not configured / placeholder only
+- `SWIRL_FQDN`: configured / not configured / placeholder only
+- `TIKA_SERVER_ENDPOINT`: configured / not configured / placeholder only
+- `SWIRL_RAG_DISTRIBUTION_STRATEGY`: configured / not configured / placeholder only
+
+## Database impact
+
+Include when PostgreSQL, SQLite, migrations, dumps, restores, or data loading were involved.
+
+Track:
+
+- Database engine.
+- Database host if non-sensitive.
+- Whether migrations/configuration were run.
+- Whether data was loaded.
+- Whether backup/restore/copy was planned or run.
+- Whether destructive database commands were involved.
+
+Never include credentials.
+
+## AI Provider / SearchProvider / RAG impact
+
+Include when provider configuration was involved.
+
+Track:
+
+- AI Provider affected.
+- Role affected: `reader`, `query`, `connector`, or `rag`.
+- Whether provider was activated/deactivated.
+- Whether API keys were involved, redacted.
+- SearchProvider affected.
+- Page Fetcher configuration affected.
+- RAG distribution strategy affected.
+- Token/page limits affected.
+- Tika dependency affected.
+
+## Docker / CI impact
+
+Include when Docker builds, GitHub Actions workflows, or image publishing were involved.
+
+Track:
+
+- Docker image build/push status.
+- Registry target (`swirlai/swirl-search`), if relevant.
+- Which GitHub Actions workflow was involved.
+- Whether any mutating action (image push, workflow dispatch) was run.
+- Whether the action was planned only or executed.
+
+If a mutating action was discussed but not run, explicitly state:
+
+No mutating Docker or CI action was run.
+
+## Validation performed
+
+List validation already performed.
+
+Examples:
+
+- README instructions reviewed.
+- Script inspected.
+- Command syntax checked.
+- Local install command run.
+- Django command run.
+- Docker build run (no push).
+- GitHub Actions workflow reviewed.
+- Database connection tested.
+- SearchProvider tested.
+- AI Provider tested.
+- RAG query tested.
+- Tika endpoint tested.
+
+If nothing was validated, write:
+
+No validation performed yet.
+
+## Known issues / blockers
+
+List current blockers.
+
+Examples:
+
+- Missing PostgreSQL credentials (if using PostgreSQL instead of default SQLite).
+- `.env` incomplete.
+- Docker daemon unavailable.
+- Tika container not running.
+- OIDC callback values unknown.
+- SearchProvider API key not configured.
+- Potential secret exposure needs review.
+- Script has network-mutating behavior and needs approval before execution.
+
+## Risks
+
+List operational/security risks.
+
+Always include this section for work involving scripts, secrets, deployment, database, provider activation, or external integrations.
+
+Examples:
+
+- Running setup commands may mutate the local database.
+- AI Provider activation may change runtime LLM behavior.
+- SearchProvider changes may affect federated search behavior.
+- RAG configuration changes may affect answer quality or token usage.
+- Tika misconfiguration may break binary document extraction.
+- API key/client secret must not be committed.
+
+## Next steps
+
+List precise next actions.
+
+Each next step should be actionable and scoped.
+
+## Recommended resume prompt
+
+Write a short prompt that can be pasted into the next Claude Code session.
+
+Example:
+
+```text
+Continue the SWIRL setup task from the handoff below. First review the files listed under "Files changed" and "Files inspected". Do not run mutating Docker, database, or network commands without explicit approval. Preserve secret redaction rules.
+```
+```
+
+## Domain-specific guidance
+
+### Local installation handoff
+
+If the task involved local installation, explicitly preserve which install steps were completed.
+
+### OAuth/OIDC/MSAL handoff
+
+If the task involved authentication, report variable names and status only:
+
+```md
+- `OIDC_RP_CLIENT_ID`: configured / not configured / placeholder only
+- `OIDC_RP_CLIENT_SECRET`: redacted / not inspected
+- `MS_AUTH_CLIENT_ID`: configured / not configured / placeholder only
+- `MS_TENANT_ID`: configured / not configured / placeholder only
+- `MSAL_CB_PORT`: configured / not configured / placeholder only
+- `MSAL_HOST`: configured / not configured / placeholder only
+```
+
+### AI Provider handoff
+
+If the task involved AI Providers, preserve role and activation details:
+
+```md
+- Provider name: <name or unknown>
+- Role: reader / query / connector / rag
+- Activation change: yes/no
+- API key touched: yes, redacted / no
+- Model changed: <model or unknown>
+- Defaults changed: yes/no/unknown
+```
+
+### SearchProvider handoff
+
+If the task involved SearchProviders, preserve:
+
+```md
+- SearchProvider: <name or unknown>
+- `page_fetch_config_json` changed: yes/no
+- Diffbot involved: yes/no
+- Microsoft Graph involved: yes/no
+- Tika required: yes/no
+- Timeout/cache/header behavior changed: yes/no
+```
+
+### RAG / Tika handoff
+
+If the task involved RAG or Tika, preserve:
+
+```md
+- `SWIRL_RAG_DISTRIBUTION_STRATEGY`: Distributed / RoundRobin / Sorted / unknown
+- `SWIRL_RAG_MODEL`: <model or unknown>
+- `SWIRL_RAG_TOK_MAX`: <value or unknown>
+- `SWIRL_RAG_MAX_TO_CONSIDER`: <value or unknown>
+- `TIKA_SERVER_ENDPOINT`: configured / not configured / placeholder only
+- Tika container running: yes/no/unknown
+```
+
+### DevUtils handoff
+
+If the task involved scripts, preserve script-level risk classification:
+
+```md
+| Script | Purpose | Risk | Status |
+|---|---|---|---|
+| `<path>` | `<summary>` | read-only / local-mutating / networked / secret-sensitive | inspected / run / not run |
+```
+
+Risk classification:
+
+- `read-only`: prints, checks, renders, or inspects.
+- `local-mutating`: modifies local files, local database, or local environment.
+- `networked`: calls external services, indexes remote data, or connects to search backends.
+- `secret-sensitive`: reads, writes, prints, transforms, or depends on credentials, API keys, tokens, or private configuration.
+
+## Final quality checklist
+
+Before returning the handoff, verify:
+
+- [ ] No secret values are included.
+- [ ] Exact files changed are listed.
+- [ ] Commands are listed with working directory and result.
+- [ ] Script paths are listed if scripts were involved.
+- [ ] Mutating actions are clearly labeled.
+- [ ] Validation status is explicit.
+- [ ] Known blockers are explicit.
+- [ ] Next steps are actionable.
+- [ ] A recommended resume prompt is included.

--- a/.claude/skills/devutils-script-review/SKILL.md
+++ b/.claude/skills/devutils-script-review/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: devutils-script-review
+description: Use this skill to review, document, or propose safe execution of scripts under DevUtils/.
+---
+
+# DevUtils Script Review Skill
+
+## Objective
+
+Classify a DevUtils script before use and produce a safe execution recommendation.
+
+## Known scripts
+
+| Script | Risk level | Notes |
+|---|---|---|
+| `pre-checkin-tests.sh` | local | runs pytest + smoke tests |
+| `run-integtration-tests.sh` | local + networked | requires live Swirl instance |
+| `verify_search.py` | networked | POSTs to a search URL; requires credentials |
+| `clone_swirl.sh` | credentialed | prompts for GitHub PAT interactively |
+| `fix_csv.py` | local-mutating | modifies local CSV files |
+| `index_email_elastic.py` | networked + credentialed | indexes into Elasticsearch |
+| `index_email_opensearch.py` | networked + credentialed | indexes into OpenSearch |
+| `Swirl.postman_collection.json` | read-only | may contain auth token examples |
+
+## Process
+
+1. Read the script.
+2. Identify inputs, flags, defaults, and outputs.
+3. Identify whether it touches local files, external APIs, search indexes, or auth systems.
+4. Identify secrets or credentials involved.
+5. Identify dry-run or read-only options.
+6. Recommend a safe command or state that manual approval is required.
+
+## Output format
+
+```md
+## Script
+## Purpose
+## Inputs/flags
+## External systems touched
+## Mutating behavior
+## Secrets involved
+## Safe execution mode
+## Recommended command
+## Approval required
+```
+
+## Rules
+
+- Do not run credentialed or mutating scripts without approval.
+- Do not print secrets.
+- Prefer dry-run options when available.

--- a/.claude/skills/docker-image-build-plan/SKILL.md
+++ b/.claude/skills/docker-image-build-plan/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: docker-image-build-plan
+description: Use this skill when reviewing or discussing Docker image builds, GitHub Actions Docker workflows, or Docker Hub publishing for swirl-search.
+---
+
+# Docker Image Build Plan Skill
+
+## Objective
+
+Review Docker image build and publish workflows safely. In this repo, all Docker builds and pushes happen through GitHub Actions — never manually.
+
+## Build mechanism
+
+Docker images are built via `.github/workflows/`:
+
+- `docker-image.yml` — manual workflow, builds and pushes `swirlai/swirl-search:<tag>`.
+- `test-build-pipeline.yml` — automated pipeline (push to `main`/`develop`); unit-tests → db-dist → qa-suite → docker build+push.
+
+The `Dockerfile` at the root builds a multi-arch (`linux/amd64,linux/arm64`) image. The tag is `latest` on `main` and the branch name on other branches.
+
+## Process
+
+1. Identify whether a manual or automated build is needed.
+2. Confirm branch and the resulting image tag.
+3. Confirm Docker Hub secrets (`SBS_DOCKER_USER`, `SBS_DOCKER_PAT`) are in place — do not print them.
+4. Confirm SBOM and provenance attestation requirements.
+5. Identify any Dockerfile changes and validate locally with `docker build` (no `--push`).
+6. Document produced tags.
+
+## Output format
+
+```md
+## Image build summary
+## Workflow used
+## Branch/tag
+## Build platform
+## Push behavior
+## Secrets involved
+## Local validation command (no --push)
+## Approval required
+## Risks
+```
+
+## Rules
+
+- Do not run `docker login` or `docker push` outside GitHub Actions without explicit approval.
+- Do not print Docker Hub credentials.
+- Local test builds must omit `--push`.

--- a/.claude/skills/local-install-plan/SKILL.md
+++ b/.claude/skills/local-install-plan/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: local-install-plan
+description: Use this skill before installing, configuring, or troubleshooting a local SWIRL community environment.
+---
+
+# Local Install Plan Skill
+
+## Objective
+
+Create a safe, reviewable local installation or troubleshooting plan for SWIRL community edition.
+
+## Installation flow
+
+```bash
+git clone -b develop <repository-url> swirl-search
+cd swirl-search
+./install.sh              # pip install, spacy model, NLTK
+python swirl.py setup     # migrations, initial admin, collectstatic
+./install-ui.sh -p        # pull swirlai/spyglass:preview, copy to static/galaxy/
+python swirl.py start     # start Daphne + Celery
+```
+
+## Process
+
+1. Confirm platform is supported (Linux/macOS, Python 3.11+).
+2. Confirm Python, Redis, disk, and memory prerequisites.
+3. Identify whether this is a fresh install, upgrade, or repair.
+4. Check whether `.env` exists without printing it.
+5. Plan DB setup steps (`python swirl.py setup`).
+6. Plan UI install steps (`./install-ui.sh -p` or `--directory` for local build).
+7. Plan startup and validation.
+
+## Output format
+
+```md
+## Install goal
+## Prerequisites
+## Files/configuration involved
+## Secrets handling
+## Commands to run
+## Validation
+## Risks
+## Rollback/cleanup
+```
+
+## Rules
+
+- Do not print `.env` values.
+- Do not run install/start commands unless explicitly approved.
+- Mark local/disposable environment vs any external system clearly.
+- `./install-ui.sh` requires Docker to be running unless using `-d <local-dir>`.

--- a/.claude/skills/search-provider-and-rag-review/SKILL.md
+++ b/.claude/skills/search-provider-and-rag-review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: search-provider-and-rag-review
+description: Use this skill when changing SearchProvider, AI Provider, Page Fetcher, Tika, or RAG configuration.
+---
+
+# Search Provider and RAG Review Skill
+
+## Objective
+
+Review search, provider, and RAG configuration safely.
+
+## Process
+
+1. Identify whether the change affects SearchProviders, AI Providers, Page Fetcher, Tika, or RAG.
+2. Identify provider roles and active/default behavior.
+3. Identify secrets in provider JSON/configuration.
+4. Check model and token configuration.
+5. Check page fetching timeout/fallback behavior.
+6. Check Tika endpoint and MIME whitelist.
+7. Define validation searches or API calls.
+
+## Output format
+
+```md
+## Change summary
+## SearchProvider impact
+## AI Provider impact
+## RAG behavior impact
+## Page Fetcher/Tika impact
+## Secrets involved
+## Validation plan
+## Rollback notes
+```
+
+## Rules
+
+- Do not expose provider API keys.
+- Do not generate real provider secrets.
+- Use sanitized sample JSON only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,187 @@
+# CLAUDE.md
+
+Operating guide for Claude Code in the SWIRL Community (`swirl-search`) backend.
+
+## What SWIRL is
+
+Federated search engine with RAG. NLP plus embeddings re-rank results from many sources, and data stays in its original location (OneDrive, Box, databases, search engines, and so on). The current focus is better access to enterprise data than a straight per-repo MCP search would give.
+
+The SWIRL Assistant (chat plus RAG over federated results) is in scope and drives the federated-SQL demo work. Do not treat the assistant as discontinued.
+
+## Working conventions
+
+### Branching and releases
+
+- All work happens on feature or fix branches.
+- Feature/fix branches merge to `develop`. Documentation branches merge to `main`.
+- `develop` merges to `main` only as part of a release.
+- Never push directly to `main`. Push a feature branch to its same-name remote. Ask if ambiguous.
+- Claude pushes to feature/fix branches and gives the user the PR URL. The user merges.
+
+### The two repos
+
+- Backend/core: `swirl-search` (this repo).
+- Frontend: `swirl-galaxy` (distributed as `swirlai/spyglass` Docker image). `install-ui.sh` pulls the image and copies the built assets into `static/galaxy/`.
+- Cross-cutting features may need changes in both repos.
+
+### Galaxy UI install (the top "it's not working" trap)
+
+Two layers, do not confuse them:
+
+| Layer  | Path                    | What                           |
+|--------|-------------------------|--------------------------------|
+| Built  | Docker image (pulled)   | `swirlai/spyglass` or `--preview` |
+| Served | `static/galaxy/`        | what Django serves             |
+
+Running `./install-ui.sh` (or `./install-ui.sh -p` for preview) pulls the image and copies assets into `static/galaxy/`. Editing nothing in this repo changes the UI — the source lives in `swirl-galaxy`. Hard-refresh (Cmd-Shift-R) after install. For local testing, use `-p` (preview) unless on a release branch.
+
+### URL routing
+
+`swirl.urls` is mounted under two prefixes in `swirl_server/urls.py`: `/swirl/...` and
+`/api/swirl/...`, both hitting the same views. Galaxy uses `/api/`; `curl` works with either.
+
+### Release branches
+
+`main_prerelease_X_Y_Z` is cut from main, merges develop once, then sits. When a regression is reported on a release branch, check if the fix is already on develop and merge develop forward. Do not cherry-pick unless there is no alternative; cherry-picks tend to re-introduce regressions. Flag any cherry-pick as "triage, not the cure".
+
+### When the user reports a problem
+
+Their report is data, not a hypothesis to question. Investigate: `logs/django.log`, celery worker logs, the served bundle (`static/galaxy/`), what is actually running (`.pyc` mtime, `git log`). "Are you sure?" / "Did you restart?" / "Try again" are anti-patterns.
+
+### Tests and closing out
+
+- After any coding session: review tests, update them, add new ones, run them all.
+- Nothing is done until all tests pass. Tests must reflect the user's experience, not just that the code executes.
+- Verify before claiming done: code edit -> `pytest` the affected tests; backend endpoint -> `curl` the live endpoint; UI change -> reinstall, hard-refresh, inspect; git op -> `git status` / `git diff origin/<branch>`.
+- Verify UI changes in a browser before turning work over.
+
+### Ops
+
+- Never restart workers individually. `python swirl.py restart` kills the whole stack (Celery plus Daphne restart together). Do not restart mid-demo without an OK.
+
+### Tone
+
+No glazing, no unreasonable positivity. Push back when something is wrong. Always be seeking to delight the SWIRL user.
+
+## Operating discipline
+
+Before any multi-step action, state in one sentence each: starting repo/branch, ending repo/branch, what gets pushed where. If you cannot, stop and work it out first.
+
+Force-pushes: auto-mode denies them. If work needs a force-push (rebase, history rewrite), ask for authorization before the rebase, not after.
+
+## Local installation flow
+
+```bash
+git clone -b develop <repository-url> swirl-search
+cd swirl-search
+./install.sh
+python swirl.py setup
+./install-ui.sh -p
+python swirl.py start
+```
+
+Do not run install commands automatically unless the user asks and the target is clearly local or disposable.
+
+## Security and secrets
+
+This repo holds sensitive operational assets. Treat it as sensitive by default.
+
+- Never print real API keys, OAuth/OIDC client secrets, DB passwords, tokens, private keys, or full `.env` contents. Use placeholders: `<api-key>`, `<client-secret>`, `<tenant-id>`, `<docker-token>`, `<database-password>`.
+- Do not read `.env` without approval; do not suggest committing `.env` or credential-bearing files.
+- When generating reusable docs: remove personal names and emails, replace local absolute paths with generic ones.
+
+Treat the following paths as sensitive — do not print values from them:
+
+```text
+.env
+.env.*
+*.pem
+*.key
+swirl_server/settings*.py    (may contain DB credentials or secret key)
+Postman collections containing auth examples
+```
+
+## High-risk commands (never run automatically; explicit approval required)
+
+```text
+docker login / docker push / docker buildx build --push
+pg_restore / psql DROP|TRUNCATE
+```
+
+Prefer dry-run or review-only workflows where available. For Docker image builds, they are handled via GitHub Actions workflows — do not push images manually.
+
+## Repo areas
+
+- `DevUtils/`: dev, support, test, data, and API helpers. Read a script before suggesting its use; classify it read-only / local-mutating / networked / credentialed; gate credentialed and network-indexing scripts behind approval.
+- `swirl_server/`: Django project (settings, urls). `static/galaxy/`: the served Galaxy UI bundle.
+- `SearchProviders/`: provider JSON definitions loaded via `python swirl_load.py`.
+- `AIProviders/`: AI provider JSON definitions loaded via `python swirl_load.py`.
+- `.github/workflows/`: CI/CD pipelines (unit-tests, QA suite, Docker build, db-dist, docs).
+
+## CI/CD workflows
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `unit-tests.yml` | PR to `develop` | pytest unit tests |
+| `test-build-pipeline.yml` | push to `main`/`develop` | unit-tests → db-dist → qa-suite → docker build+push |
+| `docker-image.yml` | manual | Docker build+push only |
+| `qa-suite.yml` | manual | QA behave suite against live Swirl |
+| `db-dist.yml` | via pipeline | regenerates `db.sqlite3.dist` |
+
+Docker image: `swirlai/swirl-search`. Built and pushed via GitHub Actions only — never manually.
+
+## AI Providers, Search, RAG, and the SWIRL Assistant
+
+Provider roles: `reader`, `query`, `connector`, `rag`. Provider config may include `api_key`, `model`, `config`, `tags`, `defaults`. Do not print provider keys. Assume one active default per role unless code says otherwise. When changing RAG, check token limits, model compatibility, source ordering, and fallback. Page Fetcher and Tika changes affect extraction and RAG quality; validate MIME allowlists. Treat provider activate/deactivate as a runtime behavior change.
+
+The SWIRL Assistant (chat plus RAG over federated results) is in scope. Changes that touch assistant routes, prompt assembly, or RAG distribution strategy must be verified end-to-end.
+
+## Recommended validation
+
+For Python changes:
+
+```bash
+python -m compileall <path>
+```
+
+For pre-checkin:
+
+```bash
+./install-test.sh
+./DevUtils/pre-checkin-tests.sh
+```
+
+These require test dependencies (`requirements-test.txt`) and a running local SWIRL instance. Confirm prerequisites before running.
+
+## Pull request summary
+
+Match the structure from `.github/pull_request_template.md`. For code changes, also include:
+
+```md
+## Summary
+## Type of change
+## Files changed
+## Runtime impact
+## Search/RAG/Assistant impact
+## Secrets impact
+## Testing and Validation
+```
+
+## Context handoff
+
+Use the context handoff skill before compacting, ending a session, or switching tasks. Capture:
+
+- Current goal and branch.
+- Files changed or reviewed.
+- Commands run.
+- Local install/configuration status.
+- SearchProvider, AI Provider, RAG, Tika, or Page Fetcher changes.
+- Known blockers and next safe action.
+
+Never include secret values in a handoff.
+
+## .claude structure
+
+- Agents: `.claude/agents/`
+- Skills: `.claude/skills/<name>/SKILL.md` (must live here to be auto-discovered)
+- Commands: `.claude/commands/`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: claude-init
+claude-init:
+	@if [ ! -f .claude/settings.json ]; then \
+		cp .claude/settings.example.json .claude/settings.json; \
+		echo "Created .claude/settings.json from .claude/settings.example.json"; \
+	else \
+		echo ".claude/settings.json already exists; leaving it unchanged"; \
+	fi
+
+.PHONY: claude-check
+claude-check:
+	@test -f CLAUDE.md || (echo "Missing CLAUDE.md" && exit 1)
+	@test -d .claude || (echo "Missing .claude directory" && exit 1)
+	@test -f .claude/settings.example.json || (echo "Missing .claude/settings.example.json" && exit 1)
+	@echo "Claude Code files are present"


### PR DESCRIPTION
# Add Claude Code operating model (CLAUDE.md, skills, agents, rules, commands)

## Summary

- Adds `CLAUDE.md` — the primary operating guide for Claude Code sessions in this repo, covering branching conventions, secrets handling, high-risk commands, repo areas, CI/CD overview, and RAG/provider guidance.
- Adds `.claude/` directory structure with agents, commands, skills, rules, and an example settings file to establish a consistent Claude Code operating model.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / tooling
- [ ] Refactor
- [ ] Other

## Files changed

| File | Change |
|---|---|
| `CLAUDE.md` | New — top-level Claude Code operating guide |
| `.claude/README.md` | New — describes the `.claude/` directory layout |
| `.claude/settings.example.json` | New — conservative local permission example (allow/ask/deny) |
| `.claude/agents/devutils-reviewer.md` | New — agent: reviews DevUtils scripts for safety and secrets |
| `.claude/agents/search-rag-reviewer.md` | New — agent: reviews SearchProvider, AI Provider, RAG, Tika changes |
| `.claude/agents/security-compliance-reviewer.md` | New — agent: reviews secrets, auth, and GitHub Actions credential usage |
| `.claude/commands/context-handoff.md` | New — slash command: triggers context-handoff skill |
| `.claude/commands/devutils-script-review.md` | New — slash command: triggers devutils-script-review skill |
| `.claude/commands/docker-image-build-plan.md` | New — slash command: triggers docker-image-build-plan skill |
| `.claude/commands/local-install-plan.md` | New — slash command: triggers local-install-plan skill |
| `.claude/commands/search-provider-and-rag-review.md` | New — slash command: triggers search-provider-and-rag-review skill |
| `.claude/rules/deployment-and-infra.md` | New — rule: CI/CD and Docker safety guardrails |
| `.claude/rules/devutils.md` | New — rule: DevUtils script classification and usage gates |
| `.claude/rules/search-rag.md` | New — rule: search and RAG provider review dimensions |
| `.claude/rules/security-and-secrets.md` | New — rule: secret/credential handling policy |
| `.claude/skills/context-handoff/SKILL.md` | New — skill: structured session handoff with secret redaction |
| `.claude/skills/devutils-script-review/SKILL.md` | New — skill: classify and safely recommend DevUtils script execution |
| `.claude/skills/docker-image-build-plan/SKILL.md` | New — skill: review Docker build/publish workflows |
| `.claude/skills/local-install-plan/SKILL.md` | New — skill: plan safe local SWIRL community installation |
| `.claude/skills/search-provider-and-rag-review/SKILL.md` | New — skill: review search, provider, and RAG configuration |

## Runtime impact

None. All files are documentation and Claude Code tooling — no Python, Django, Celery, or SWIRL runtime code is modified.

## Search/RAG/Assistant impact

None. No SearchProvider, AI Provider, Page Fetcher, Tika, or RAG configuration is changed.

## Secrets impact

None. No secrets are introduced or changed. The `settings.example.json` explicitly denies reading `.env`, `.env.*`, `*.pem`, and `*.key` files. No credential values are present in any added file.

## Testing and Validation

- All added files are Markdown and JSON — no Python compilation required.
- `settings.example.json` is valid JSON.
- Skills and agents are readable by Claude Code via the `.claude/` directory convention.
- No SWIRL runtime changes; existing tests are unaffected.
