### PR TITLE
Release 4.5.0.7

### DIFF
--- a/swirl/banner.py
+++ b/swirl/banner.py
@@ -10,7 +10,7 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
 
-SWIRL_VERSION = '4.5.0.6'
+SWIRL_VERSION = '4.5.0.7'
 
 SWIRL_BANNER_TEXT = f"SWIRL AI COMMUNITY {SWIRL_VERSION}"
 

--- a/swirl/tests/test_security_1941.py
+++ b/swirl/tests/test_security_1941.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for GitHub issue #1941:
+
+  1. OIDC sign-in must NOT provision superuser/staff accounts, and must not
+     install a shared, usable password (Basic-auth backdoor).
+  2. The Microsoft OauthToken DB fallback must be scoped to the requesting
+     user — it must never return another user's token (cross-user exposure).
+
+Run with:  pytest swirl/tests/test_security_1941.py -v
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import RequestFactory
+from rest_framework.test import APIRequestFactory
+
+from swirl.models import OauthToken
+from swirl.views import OidcAuthView, get_session_data_with_db_fallback
+
+
+# ---------------------------------------------------------------------------
+# Bug #2 — cross-user Microsoft token fallback
+# ---------------------------------------------------------------------------
+
+def _make_request(user):
+    req = RequestFactory().get('/api/swirl/search/')
+    req.user = user
+    req.session = {}          # no browser session -> Authenticator returns False
+    return req
+
+
+@pytest.mark.django_db
+def test_no_cross_user_token_fallback():
+    """User A (no token) must NOT receive User B's Microsoft token."""
+    user_a = User.objects.create_user(username='alice', password='pw')
+    user_b = User.objects.create_user(username='bob', password='pw')
+    OauthToken.objects.create(owner=user_b, idp='Microsoft', token='BOB-SECRET-TOKEN')
+
+    result = get_session_data_with_db_fallback(_make_request(user_a))
+
+    # Alice has no token of her own; she must get nothing — never Bob's.
+    assert not result or result.get('microsoft_access_token') != 'BOB-SECRET-TOKEN'
+
+
+@pytest.mark.django_db
+def test_own_token_still_returned():
+    """A user WITH a token still gets their own token back (no regression)."""
+    user_a = User.objects.create_user(username='alice', password='pw')
+    OauthToken.objects.create(owner=user_a, idp='Microsoft', token='ALICE-TOKEN')
+
+    result = get_session_data_with_db_fallback(_make_request(user_a))
+
+    assert result['microsoft_access_token'] == 'ALICE-TOKEN'
+
+
+# ---------------------------------------------------------------------------
+# Bug #1 — OIDC superuser provisioning
+# ---------------------------------------------------------------------------
+
+def _oidc_post():
+    req = APIRequestFactory().post('/swirl/oidc_authenticate/')
+    req.META['HTTP_OIDC_TOKEN'] = 'Bearer graph-access-token'
+    return req
+
+
+@pytest.mark.django_db
+def test_oidc_provisions_non_privileged_user():
+    """A new OIDC user must be created without superuser/staff or a usable password."""
+    with patch('swirl.views.Microsoft.get_user', return_value={'mail': 'newbie@example.com'}):
+        response = OidcAuthView().post(_oidc_post())
+
+    assert response.status_code == 200
+    user = User.objects.get(email='newbie@example.com')
+    assert user.is_superuser is False
+    assert user.is_staff is False
+    assert user.has_usable_password() is False
+    assert response.data['is_superuser'] is False
+
+
+@pytest.mark.django_db
+def test_oidc_invalid_token_forbidden():
+    """A token with no mail (e.g. expired/invalid) must return 403, not 500."""
+    with patch('swirl.views.Microsoft.get_user', return_value={'error': 'invalid'}):
+        response = OidcAuthView().post(_oidc_post())
+
+    assert response.status_code == 403

--- a/swirl/views.py
+++ b/swirl/views.py
@@ -103,18 +103,16 @@ def get_session_data_with_db_fallback(request):
                 logger.debug(f"get_session_data_with_db_fallback: DB sync skipped: {_e}")
         return session_data
 
-    # No browser session — look up the OauthToken DB row.
+    # No browser session — look up the OauthToken DB row for THIS user only.
+    # We must never fall back to another user's token: doing so would run one
+    # user's M365 search with another user's credentials (cross-user exposure).
     oauth_token = None
     if getattr(request, 'user', None) and request.user.is_authenticated:
         try:
             oauth_token = OauthToken.objects.get(owner=request.user, idp='Microsoft')
             logger.debug(f"get_session_data_with_db_fallback: loaded token from DB for {request.user}")
         except OauthToken.DoesNotExist:
-            logger.debug(f"get_session_data_with_db_fallback: no token for {request.user}, trying any Microsoft token")
-    if oauth_token is None:
-        oauth_token = OauthToken.objects.filter(idp='Microsoft').first()
-        if oauth_token:
-            logger.debug(f"get_session_data_with_db_fallback: using Microsoft token from owner={oauth_token.owner}")
+            logger.debug(f"get_session_data_with_db_fallback: no Microsoft token for {request.user}")
 
     if oauth_token:
         # Decode the real JWT expiry so we can decide whether to refresh.
@@ -288,18 +286,23 @@ class OidcAuthView(APIView):
             token = header.split(' ')[1]
             if token:
                 data = Microsoft().get_user(token)
-                if data['mail']:
+                if data.get('mail'):
                     user = None
                     try:
                         user = User.objects.get(email=data['mail'])
                     except User.DoesNotExist:
+                        # Provision a regular (non-privileged) user. OIDC sign-in must
+                        # never confer superuser/staff rights, and these accounts
+                        # authenticate via the token flow only, so they get no usable
+                        # password (no shared Basic-auth backdoor).
                         user = User.objects.create_user(
                             username=data['mail'],
-                            password='WQasdmwq2319dqwmk',
                             email=data['mail'],
-                            is_superuser=True,
-                            is_staff=True
+                            is_superuser=False,
+                            is_staff=False
                         )
+                        user.set_unusable_password()
+                        user.save()
                     token, created = Token.objects.get_or_create(user=user)
                     return Response({ 'user': user.username, 'token': token.key, 'swirl_version': SWIRL_VERSION, 'is_superuser': user.is_superuser, 'edition': 'community' })
                 return HttpResponseForbidden()


### PR DESCRIPTION
Security patch for #1941.

- **OIDC** (`OidcAuthView`): new users provisioned non-privileged (no `is_superuser`/`is_staff`), with an unusable password (removes the shared Basic-auth backdoor); invalid token → 403, not 500.
- **Microsoft token lookup** (`get_session_data_with_db_fallback`): scoped strictly to the requesting user; removed the cross-user `.filter(idp='Microsoft').first()` fallback.
- Adds `swirl/tests/test_security_1941.py` (4 regression tests). Backend suite: 184 passed.
- `swirl/banner.py`: 4.5.0.6 → 4.5.0.7.
- No dependency or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)