### PR TITLE
fix(code_quality): Missing docstring on public function `check_pid` in swirl.py

### DIFF
--- a/swirl.py
+++ b/swirl.py
@@ -52,6 +52,11 @@ def service_is_retired(service_name):
 
 
 def check_pid(pid):
+    """Check whether a process with the given PID is currently running.
+
+    Runs ``ps -p <pid>`` and returns True if the PID appears in the output,
+    False otherwise.
+    """
     proc = subprocess.run(['ps','-p',str(pid)], capture_output=True)
     result = proc.stdout.decode('UTF-8')
     return str(pid) in result


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `check_pid` in swirl.py (swirlai/swirl-search)

**Wedge type:** `code_quality`

**Issue:** https://github.com/swirlai/swirl-search/blob/main/swirl.py

## Changes

- `swirl.py`

**Diff size:** 5 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>