### PR TITLE
fix(code_quality): Missing docstring on public function `load_swirl_file` in sw

### DIFF
--- a/swirl.py
+++ b/swirl.py
@@ -59,6 +59,13 @@ def check_pid(pid):
 ##################################################
 
 def load_swirl_file():
+    """
+    Load the .swirl PID file from the current directory.
+
+    Returns a dict mapping service names to PIDs when the file exists and
+    is valid JSON, an empty dict when the file does not exist, or False if
+    the file cannot be read.
+    """
     if os.path.exists('.swirl'):
         try:
             swirl_file = open('./.swirl', 'r')


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `load_swirl_file` in swirl.py (swirlai/swirl-search)

**Wedge type:** `code_quality`

**Issue:** https://github.com/swirlai/swirl-search/blob/main/swirl.py

## Changes

- `swirl.py`

**Diff size:** 7 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>