### PR TITLE
fix(code_quality): Missing docstring on public function `service_is_retired` in

### DIFF
--- a/swirl.py
+++ b/swirl.py
@@ -38,6 +38,10 @@ STOP_POLL         = 0.25
 COMMAND_LIST = [ 'help', 'start', 'debug', 'start_sleep', 'stop', 'restart', 'migrate', 'setup', 'status', 'watch', 'logs' ]
 
 def service_is_retired(service_name):
+    """
+    Return True if the named service is marked as retired in SERVICES, False otherwise.
+    Prints a notice when a retired service is encountered.
+    """
     ret = False
     try:
         for service in SERVICES:


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `service_is_retired` in swirl.py (swirlai/swirl-search)

**Wedge type:** `code_quality`

**Issue:** https://github.com/swirlai/swirl-search/blob/main/swirl.py

## Changes

- `swirl.py`

**Diff size:** 4 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>