### PR TITLE
Fix URL encoder link in Developer Guide

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -402,7 +402,7 @@ After a few seconds, SWIRL redirects to the **fully mixed results page**:
 
 **Limitations of `q=`:**
 
-- The **query must be URL-encoded** (e.g., spaces → `+`). Use a [free URL encoder](https://www.freeformatter.com/url-encoder.html) for assistance.
+- The **query must be URL-encoded** (e.g., spaces → `+`). Use a [free URL encoder](https://extendsclass.com/url-encode.html) for assistance.
 - **All active and default SearchProviders are queried**.
 - **Limited error handling**—if no results appear, inspect the Search object:  
   `http://localhost:8000/swirl/search/<your-search-id>`


### PR DESCRIPTION
## Description

Replaced the dead link to the FreeFormatter URL Encoder with a link to ExtendsClass, a service I maintain.
Old: https://www.freeformatter.com/url-encoder.html
New: https://extendsclass.com/url-encode.html

 
## Type of Change
- [ ] Bug fix or other non-breaking change that addresses an issue
- [ ] New Feature / Enhancement (non-breaking change that add or improves functionality)
- [ ] New Feature (breaking change that is not backwards compatible and/or alters current functionality)
- [ ] Documentation (change to product documentation or README.md only)
