### PR TITLE
DS-5681: configure the Backstage JWKS harness for the Community QA gate

### DIFF
--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -138,23 +138,10 @@ jobs:
           env:
             MSAL_CB_PORT: 8000
             MSAL_HOST: localhost
-        # DS-5681: SWIRL for Backstage verifies the ES256 plugin token the
-        # engine module forwards against the JWK set published at
-        # SWIRL_BACKSTAGE_JWKS_URL. swirl/backstage_bearer.py treats an empty
-        # URL as "the Backstage path is off" (is_backstage_enabled() needs a
-        # URL *and* an audience), so with neither configured every request in
-        # the backstage_* QA group is refused 401 and 24 scenarios fail
-        # without ever reaching the code they cover.
-        #
-        # The key pair is minted by the QA image's own BackstageTokenFactory
-        # rather than re-implemented here, so the key/JWKS format has one
-        # definition and cannot drift between this workflow and the suite
-        # that signs the tokens. The image is pulled by the QA step below
-        # anyway, so this costs no extra download.
-        #
-        # Both steps must run before "Start Swirl": settings.py reads the
-        # JWKS URL at startup. The JWK set itself is fetched lazily on the
-        # first token, so the server only has to be up by then.
+        # The backstage_* scenarios sign ES256 plugin tokens that SWIRL
+        # verifies against this JWK set. Minted by the QA image's own
+        # BackstageTokenFactory so the key format has a single definition.
+        # Must precede "Start Swirl": settings.py reads the URL at startup.
         - name: Mint the Backstage JWKS key pair
           run: |
             mkdir -p "${{ github.workspace }}/backstage-jwks"
@@ -184,7 +171,7 @@ jobs:
             SWIRL_RAG_MODEL: gpt-4.1
             SWIRL_REWRITE_MODEL: gpt-4.1
             SWIRL_QUERY_MODEL: gpt-4.1
-            # Must match QA_BACKSTAGE_AUDIENCE in the suite (default 'search').
+            # Audience must match QA_BACKSTAGE_AUDIENCE in the suite.
             SWIRL_BACKSTAGE_JWKS_URL: http://127.0.0.1:8899/jwks.json
             SWIRL_BACKSTAGE_AUDIENCE: search
         - name: PATCH the Web PSE Config
@@ -240,9 +227,7 @@ jobs:
             echo "QA_GITHUB_TOKEN=${{ secrets.QA_GITHUB_TOKEN }}" >> .env.qa
             echo "BIGQUERY_TOKEN_PATH=${{ github.workspace }}/token.json" >> .env.qa
             echo "QA_TRELLO_KEYS=${{ secrets.QA_TRELLO_KEYS }}" >> .env.qa
-            # DS-5681: the suite signs its Backstage tokens with the private
-            # key behind the JWKS URL the backend was started against, so it
-            # has to read the same directory that was minted above.
+            # The suite signs with the private key behind the JWKS URL above.
             echo "QA_BACKSTAGE_JWKS_DIR=/backstage-jwks" >> .env.qa
             echo "QA_BACKSTAGE_AUDIENCE=search" >> .env.qa
             echo "========"

--- a/.github/workflows/test-build-pipeline.yml
+++ b/.github/workflows/test-build-pipeline.yml
@@ -138,6 +138,42 @@ jobs:
           env:
             MSAL_CB_PORT: 8000
             MSAL_HOST: localhost
+        # DS-5681: SWIRL for Backstage verifies the ES256 plugin token the
+        # engine module forwards against the JWK set published at
+        # SWIRL_BACKSTAGE_JWKS_URL. swirl/backstage_bearer.py treats an empty
+        # URL as "the Backstage path is off" (is_backstage_enabled() needs a
+        # URL *and* an audience), so with neither configured every request in
+        # the backstage_* QA group is refused 401 and 24 scenarios fail
+        # without ever reaching the code they cover.
+        #
+        # The key pair is minted by the QA image's own BackstageTokenFactory
+        # rather than re-implemented here, so the key/JWKS format has one
+        # definition and cannot drift between this workflow and the suite
+        # that signs the tokens. The image is pulled by the QA step below
+        # anyway, so this costs no extra download.
+        #
+        # Both steps must run before "Start Swirl": settings.py reads the
+        # JWKS URL at startup. The JWK set itself is fetched lazily on the
+        # first token, so the server only has to be up by then.
+        - name: Mint the Backstage JWKS key pair
+          run: |
+            mkdir -p "${{ github.workspace }}/backstage-jwks"
+            docker run --rm \
+              -v "${{ github.workspace }}/backstage-jwks:/jwks" \
+              -e QA_BACKSTAGE_JWKS_DIR=/jwks \
+              swirlai/swirl-search-qa:automated-tests-develop \
+              python -c "from support.backstage_auth import token_factory; print('kid:', token_factory().load()[1])"
+            ls -l "${{ github.workspace }}/backstage-jwks"
+        - name: Serve the Backstage JWKS
+          run: |
+            cd "${{ github.workspace }}/backstage-jwks"
+            nohup python -m http.server 8899 --bind 127.0.0.1 \
+              > "${{ github.workspace }}/jwks-server.log" 2>&1 &
+            for i in $(seq 1 20); do
+              curl -sf http://127.0.0.1:8899/jwks.json > /dev/null && break
+              sleep 0.5
+            done
+            curl -sf http://127.0.0.1:8899/jwks.json
         - name: Start Swirl
           run: |
             echo "OPENAI_API_KEY='${{ secrets.QA_OPENAI_KEY }}'" >> .env
@@ -148,6 +184,9 @@ jobs:
             SWIRL_RAG_MODEL: gpt-4.1
             SWIRL_REWRITE_MODEL: gpt-4.1
             SWIRL_QUERY_MODEL: gpt-4.1
+            # Must match QA_BACKSTAGE_AUDIENCE in the suite (default 'search').
+            SWIRL_BACKSTAGE_JWKS_URL: http://127.0.0.1:8899/jwks.json
+            SWIRL_BACKSTAGE_AUDIENCE: search
         - name: PATCH the Web PSE Config
           env:
             JSON: ${{ secrets.QA_PSE_WEB }}
@@ -201,6 +240,11 @@ jobs:
             echo "QA_GITHUB_TOKEN=${{ secrets.QA_GITHUB_TOKEN }}" >> .env.qa
             echo "BIGQUERY_TOKEN_PATH=${{ github.workspace }}/token.json" >> .env.qa
             echo "QA_TRELLO_KEYS=${{ secrets.QA_TRELLO_KEYS }}" >> .env.qa
+            # DS-5681: the suite signs its Backstage tokens with the private
+            # key behind the JWKS URL the backend was started against, so it
+            # has to read the same directory that was minted above.
+            echo "QA_BACKSTAGE_JWKS_DIR=/backstage-jwks" >> .env.qa
+            echo "QA_BACKSTAGE_AUDIENCE=search" >> .env.qa
             echo "========"
             cat .env.qa
             echo "========"
@@ -211,6 +255,7 @@ jobs:
             docker run --net=host --env-file .env.qa \
               -v "${{ github.workspace }}/SearchProviders:/swirl/SearchProviders:ro" \
               -v "${{ github.workspace }}/AIProviders:/swirl/AIProviders:ro" \
+              -v "${{ github.workspace }}/backstage-jwks:/backstage-jwks:ro" \
               -e SWIRL_PRELOADED_DIR=/swirl \
               -t swirlai/swirl-search-qa:automated-tests-develop \
               sh -c "behave --tags=qa_suite,community"


### PR DESCRIPTION
## What

Configures the Backstage token harness in the `qa-suite` job of `test-build-pipeline.yml`, so the `backstage_*` QA group can actually reach the code it covers.

## Why

The Community gate failed on the two Backstage merges ([run 33817492935](https://github.com/swirlai/swirl-search/actions/runs/33817492935), [run 33824231723](https://github.com/swirlai/swirl-search/actions/runs/33824231723)) — both `qa-suite`, both ~3h18m, `89 failed, 4 error`, and the failing scenario sets are byte-identical.

Normalising by scenario name against the pre-merge baseline ([run 29693090106](https://github.com/swirlai/swirl-search/actions/runs/29693090106), `63 failed, 4 error`), **25 failures are new**; the other 68 predate these merges. 24 of the 25 are one group: every `/swirl/index/*` request in `backstage_index`, `backstage_contract`, `backstage_bearer` and `backstage_providers` refused `401 Authentication credentials were not provided`.

That 401 is **correct product behaviour, not a regression.** `swirl/backstage_bearer.py` verifies the ES256 plugin token against the JWK set at `SWIRL_BACKSTAGE_JWKS_URL`, and `is_backstage_enabled()` requires both a URL and an audience — an empty URL means the Backstage path is off. `settings.py` defaults the URL to `''`. The pipeline set neither it nor `QA_BACKSTAGE_JWKS_DIR` for the suite, so tokens were refused before reaching any covered code. The scenarios are new (swirl-search-qa `e6ec062`) and tagged `@community`, so the Community gate picked them up.

## How

- **Mint the Backstage JWKS key pair** — runs the QA image's own `BackstageTokenFactory` rather than re-implementing the key/JWKS format in YAML, so there is one definition that cannot drift from the suite that signs the tokens. That image is already pulled by the QA step, so no extra download.
- **Serve the Backstage JWKS** — a static server on `127.0.0.1:8899`.
- `SWIRL_BACKSTAGE_JWKS_URL` + `SWIRL_BACKSTAGE_AUDIENCE` on **Start Swirl**. Both new steps must precede it: `settings.py` reads the URL at startup, while the JWK set itself is fetched lazily on the first token.
- `QA_BACKSTAGE_JWKS_DIR` into `.env.qa`, and the directory mounted read-only into the QA container so the suite signs with the key behind that URL.

## Validation

Against a local SWIRL started this way, using the real factory from `swirl-search-qa`:

| Request | Result |
|---|---|
| valid service token → `GET /swirl/index/` | **200** `{"types":[]}` (CI got 401) |
| expired token | 401 |
| wrong audience | 401 |
| unknown signing key | 401 |
| no Authorization header | 401 |

behave against that instance: `backstage_index` **9/9**, `backstage_bearer` + `backstage_contract` **14/15**. The single failure is `403` on an admin-authenticated read because my local harness had no `QA_ADMIN_PW`; CI supplies it, and that scenario passes in CI today. Its three assertions were confirmed directly via the ORM (`Code - GitHub` is inactive, carries the `backstage` tag, and retains the placeholder scope).

## Scope

Community only, no QA modernisation, no Enterprise topology changes. This does **not** turn the gate green on its own — the 68 pre-existing failures remain and are not addressed here. Paired with swirlai/swirl-search-qa#379, which covers the 25th new failure.

Refs DS-5681

🤖 Generated with [Claude Code](https://claude.com/claude-code)