### PR TITLE
DS-5681: an empty cached RAG result must not 500 the detail endpoint

### DIFF
--- a/swirl/tests/test_search_rag.py
+++ b/swirl/tests/test_search_rag.py
@@ -264,6 +264,59 @@ def test_get_rag_result_serves_cache_when_request_items_match_stored(monkeypatch
     assert cached.deleted is False
 
 
+def test_get_rag_result_serves_empty_stored_result_without_indexerror(monkeypatch):
+    """REGRESSION DS-5681: a stored ChatGPT Result whose json_results is []
+    must be served as "nothing to report", not crash the endpoint.
+
+    The auto-RAG path writes such a row whenever it produces nothing — an
+    expired rag_timeout, an AI provider error, or a search with no results
+    to summarize. _try_serve_cache then read json_results[0] unconditionally
+    and raised IndexError, which DRF turned into a 500 on
+    /sapi/detail-search-rag/. Galaxy rendered the HTTP failure in the AI
+    Summary card instead of "No response from Generative AI".
+
+    Latent since the endpoint was added; it only became a 500 in 8c8d01ea,
+    which narrowed a bare `except:` to Result.DoesNotExist and moved this
+    read outside the try.
+    """
+    empty = _FakeResult(rag_query_items=[])
+    empty.json_results = []          # auto-RAG produced nothing
+    _patch_result_get(monkeypatch, empty)
+
+    sr = _make_search_rag()          # Galaxy's fetch: no rag_items in the URL
+    body_text, additional_content = sr.get_rag_result()
+
+    assert "credentials" in body_text, (
+        "with no rag_timeout the empty result should explain the likely cause"
+    )
+    assert additional_content == {}
+    assert empty.deleted is False, (
+        "an empty Result must not trigger a regenerate — that re-runs the "
+        "model on every fetch"
+    )
+
+
+def test_get_rag_result_serves_empty_stored_result_as_timeout_message(monkeypatch):
+    """With a rag_timeout, the cached-empty path must carry the documented
+    "No response from Generative AI" string.
+
+    This is the exact route rag.feature's rag_timeout scenario takes: a 2s
+    budget expires, the auto-RAG path stores a Result with no items, and
+    Galaxy then fetches detail-search-rag. Serving a bare False here put the
+    literal "False" in the AI Summary card.
+    """
+    empty = _FakeResult(rag_query_items=[])
+    empty.json_results = []
+    _patch_result_get(monkeypatch, empty)
+
+    sr = SearchRag(_FakeRequest({"rag_timeout": "2"}))
+    body_text, additional_content = sr.get_rag_result()
+
+    assert "No response from Generative AI" in body_text
+    assert "2s" in body_text
+    assert additional_content == {}
+
+
 def test_concurrent_get_rag_result_serializes_via_lock(monkeypatch):
     """REGRESSION 4.5.0.6: two simultaneous detail-search-rag calls for the
     same search_id must NOT both spin up a RAGPostResultProcessor.

--- a/swirl/views_helpers/search_rag.py
+++ b/swirl/views_helpers/search_rag.py
@@ -84,6 +84,22 @@ class SearchRag:
         additional_content = json_result.get("additional_content", {})
         return body_text, additional_content
 
+    def _no_response_message(self) -> tuple:
+        """The body Galaxy renders when RAG produced nothing.
+
+        DS-5598: with a ``rag_timeout`` the message has to carry the
+        documented "No response from Generative AI" string that
+        rag.feature asserts on. Without one, the likeliest cause is
+        credentials, so say that instead.
+        """
+        if self.rag_timeout is not None:
+            return (
+                f"Timeout: No response from Generative AI within "
+                f"{self.rag_timeout}s.",
+                {},
+            )
+        return "Please check the OpenAI or Azure OpenAI credentials in your environment.", {}
+
     def _try_serve_cache(self) -> tuple | None:
         """Cache-only check. Returns the cached body+content tuple, or None on miss.
 
@@ -101,6 +117,16 @@ class SearchRag:
             )
         except Result.DoesNotExist:
             return None
+
+        # A stored Result with no items is the auto-RAG path recording that it
+        # produced nothing — a rag_timeout that expired, an AI provider error,
+        # or a search with no results to summarize. That is a cache hit with
+        # nothing to serve, not a miss: returning None would re-run the model
+        # on every fetch, the thrash 8c8d01ea fixed. Serve the same message
+        # the generating path returns in that situation, so the reader sees
+        # why there is no summary rather than a bare False.
+        if not rag_result.json_results:
+            return self._no_response_message()
 
         stored_items = set(rag_result.json_results[0].get("rag_query_items") or [])
         requested_items = set(self.rag_query_items)
@@ -152,13 +178,7 @@ class SearchRag:
                     # AI" string the rag.feature:240 scenario asserts on.
                     # Without this branch the test sees the generic
                     # credentials message and fails.
-                    if self.rag_timeout is not None:
-                        return (
-                            f"Timeout: No response from Generative AI within "
-                            f"{self.rag_timeout}s.",
-                            {},
-                        )
-                    return "Please check the OpenAI or Azure OpenAI credentials in your environment.", {}
+                    return self._no_response_message()
 
                 if self.search_id in instances:
                     del instances[self.search_id]


### PR DESCRIPTION
A user-facing Community defect, found while rechecking the last unexplained QA gate scenario.

## The bug

`GET /swirl/sapi/detail-search-rag/` returns **500** whenever the stored `ChatGPT` Result holds no items:

```
File "swirl/views_helpers/search_rag.py", line 105, in _try_serve_cache
    stored_items = set(rag_result.json_results[0].get("rag_query_items") or [])
IndexError: list index out of range
```

The auto-RAG path writes exactly that row whenever it produces nothing — a `rag_timeout` that expired, an AI provider error, or a search with no results to summarize. Confirmed directly in the DB, two rows from different causes:

```
search_id=90:['2']:weather    json_results len=0    (rag_timeout=2 expired)
search_id=87:[]:edward tufte  json_results len=0    (provider error)
```

So any user whose LLM is slow or misconfigured gets an HTTP failure rendered inside the AI Summary card instead of a readable message. Not test-only.

## Where it came from

Latent since the endpoint was added (`9e22cb36`, 2025-05-27). It only became a **500** in `8c8d01ea` (2026-05-20), which narrowed a bare `except:` to `Result.DoesNotExist` and moved this read outside the `try`:

```python
# before — IndexError swallowed
try:
    isRagItemsUpdated = not (set(rag_result.json_results[0]["rag_query_items"]) == ...)
except:
    pass

# after — IndexError propagates
except Result.DoesNotExist:
    rag_result = None
if rag_result is not None:
    stored_items = set(rag_result.json_results[0].get("rag_query_items") or [])
```

Narrowing the bare except was the right call — it just surfaced a hidden crash without guarding it. That commit added six tests, but all use populated `json_results`, so the empty case went uncovered. `682947da` later moved the line into `_try_serve_cache` and introduced nothing.

## The fix

An empty stored Result is a **cache hit with nothing to serve**, not a miss. Returning `None` would send it down the slow path and re-run the model on every fetch — the thrash `8c8d01ea` set out to fix.

It now serves the same message the generating path already returns in that situation. That branch is extracted as `_no_response_message()` and called from both places, so the two cannot drift.

## Verified end to end

Against a local Community instance with the Galaxy async fallback (swirlai/swirl-galaxy-ui#329) in place, at `?q=weather&providers=2&rag=true&rag_timeout=2`:

| | AI Summary card |
|---|---|
| before | `Http failure response for .../detail-search-rag/...: 500 Internal Server Error` |
| after | **`Timeout: No response from Generative AI.`** |

The second is the documented string `features/search_ui/rag.feature`'s rag_timeout scenario asserts on, and results now render alongside it (10 of 106).

An intermediate version returned a bare `False`, which the serializer passed through and Galaxy rendered as the literal text "False" — hence routing through the existing message branch rather than inventing a new empty-body signal.

## Tests

Two added, both failing before this change with the `IndexError` above:

- `test_get_rag_result_serves_empty_stored_result_without_indexerror` — the no-timeout path, asserting the credentials message and that the row is **not** deleted (no regenerate).
- `test_get_rag_result_serves_empty_stored_result_as_timeout_message` — the `rag_timeout` path, asserting the documented `No response from Generative AI` string.

Suite: **606 passed**, up from 604.

## Scope

One guard, one extracted helper, two tests. No change to the cache-hit or regenerate semantics, and nothing touching the async gap.

Refs DS-5681

🤖 Generated with [Claude Code](https://claude.com/claude-code)