### PR TITLE
fix(rag): the detail-search-rag cache must honour ai_instructions

### DIFF
--- a/swirl/processors/rag.py
+++ b/swirl/processors/rag.py
@@ -349,6 +349,9 @@ class RAGPostResultProcessor(PostResultProcessor):
         if settings.SWIRL_DEFAULT_RESULT_BLOCK:
             rag_result['result_block'] = getattr(settings, 'SWIRL_DEFAULT_RESULT_BLOCK', 'ai_summary')
         rag_result['rag_query_items'] = [str(item['swirl_id']) for item in chosen_rag]
+        # Recorded so the detail-search-rag cache can tell a "Generate
+        # again with different instructions" request from a replay.
+        rag_result['ai_instructions'] = self.ai_instructions
         rag_result['additional_content'] = {
             'sources': [
                 {'title': item.get('title', ''), 'url': item.get('url', '')}

--- a/swirl/tests/test_search_rag.py
+++ b/swirl/tests/test_search_rag.py
@@ -317,6 +317,98 @@ def test_get_rag_result_serves_empty_stored_result_as_timeout_message(monkeypatc
     assert additional_content == {}
 
 
+# ---------------------------------------------------------------------------
+# Cache vs. ai_instructions. Galaxy's "Optional instructions" second pass is
+# "add instructions, press Generate again" on the SAME search: a cache keyed
+# only on search_id + rag_query_items replayed the first summary every time.
+# ---------------------------------------------------------------------------
+
+def _stub_processor(monkeypatch, body="regenerated body"):
+    """Replace RAGPostResultProcessor with a stub; returns the instance list."""
+    instances_created = []
+
+    class StubProc:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            instances_created.append(self)
+
+        def validate(self):
+            return True
+
+        def process(self, should_return=False):
+            return type("FakeResult", (), {
+                "json_results": [{
+                    "body": [body],
+                    "additional_content": {},
+                    "rag_query_items": [],
+                    "ai_instructions": self.kwargs.get("ai_instructions", ""),
+                }],
+            })()
+
+    monkeypatch.setattr(
+        "swirl.views_helpers.search_rag.RAGPostResultProcessor", StubProc
+    )
+    return instances_created
+
+
+def test_get_rag_result_regenerates_when_instructions_differ_from_stored(monkeypatch):
+    """A stored summary made without instructions must not be replayed for a
+    request that carries them — that is the second-pass flow from Galaxy."""
+    cached = _FakeResult(rag_query_items=[], body="first pass, no instructions")
+    _patch_result_get(monkeypatch, cached)
+    instances = _stub_processor(monkeypatch)
+
+    sr = SearchRag(_FakeRequest({"ai_instructions": "Answer in three bullet points."}))
+    body_text, _ = sr.get_rag_result()
+
+    assert body_text == "regenerated body"
+    assert len(instances) == 1
+    assert instances[0].kwargs["ai_instructions"] == "Answer in three bullet points."
+
+
+def test_get_rag_result_serves_cache_when_instructions_match_stored(monkeypatch):
+    cached = _FakeResult(rag_query_items=[], body="instructed body")
+    cached.json_results[0]["ai_instructions"] = "Answer in three bullet points."
+    _patch_result_get(monkeypatch, cached)
+    instances = _stub_processor(monkeypatch)
+
+    sr = SearchRag(_FakeRequest({"ai_instructions": " Answer in three bullet points. "}))
+    body_text, _ = sr.get_rag_result()
+
+    assert body_text == "instructed body"
+    assert instances == []
+    assert cached.deleted is False
+
+
+def test_get_rag_result_serves_legacy_cache_without_instructions_field(monkeypatch):
+    """Rows written before ai_instructions was recorded carry no field; a
+    plain fetch (Galaxy's auto-RAG follow-up) must still be a cache hit."""
+    cached = _FakeResult(rag_query_items=["item-a"], body="legacy body")
+    _patch_result_get(monkeypatch, cached)
+    instances = _stub_processor(monkeypatch)
+
+    body_text, _ = _make_search_rag().get_rag_result()
+
+    assert body_text == "legacy body"
+    assert instances == []
+
+
+def test_get_rag_result_regenerates_empty_stored_result_when_instructions_supplied(monkeypatch):
+    """An empty stored Result (timed-out / errored first pass) is served as a
+    message on a plain fetch (DS-5681), but a deliberate retry with
+    instructions is new input and re-runs the model."""
+    empty = _FakeResult(rag_query_items=[])
+    empty.json_results = []
+    _patch_result_get(monkeypatch, empty)
+    instances = _stub_processor(monkeypatch)
+
+    sr = SearchRag(_FakeRequest({"ai_instructions": "Try again, briefly."}))
+    body_text, _ = sr.get_rag_result()
+
+    assert body_text == "regenerated body"
+    assert len(instances) == 1
+
+
 def test_concurrent_get_rag_result_serializes_via_lock(monkeypatch):
     """REGRESSION 4.5.0.6: two simultaneous detail-search-rag calls for the
     same search_id must NOT both spin up a RAGPostResultProcessor.

--- a/swirl/views_helpers/search_rag.py
+++ b/swirl/views_helpers/search_rag.py
@@ -118,6 +118,16 @@ class SearchRag:
         except Result.DoesNotExist:
             return None
 
+        # Different AI instructions are different inputs, like a different
+        # item set: "Generate" again with new instructions must re-run the
+        # model, not replay the stored summary. Results written before the
+        # field was recorded carry none, which reads as "no instructions",
+        # so a plain fetch keeps serving them (no thrash).
+        stored = rag_result.json_results[0] if rag_result.json_results else {}
+        stored_instructions = (stored.get("ai_instructions") or "").strip()
+        if stored_instructions != self.ai_instructions:
+            return None
+
         # A stored Result with no items is the auto-RAG path recording that it
         # produced nothing — a rag_timeout that expired, an AI provider error,
         # or a search with no results to summarize. That is a cache hit with


### PR DESCRIPTION
## Problem

In Galaxy, run a search, generate an AI Summary, then type something into "Optional instructions" and press Generate again. The request goes out with `ai_instructions` on the wire, but the summary that comes back is the first one, unchanged.

Cause: since 682947da (2026-05-22) `SearchRag._try_serve_cache` keys only on `search_id` and `rag_query_items`. A second request for the same search with different instructions is a cache hit, so the model never sees them. Verified against a local Community instance by calling the endpoint directly for one search with no instructions, "Answer in exactly three bullet points." and "Answer as a haiku.": all three returned the identical 2,796-character body in about 12ms. Enterprise regenerates in this case (its cache only short-circuits when stored items are non-empty and equal).

This is independent of the Galaxy sparkle work in swirlai/swirl-galaxy-ui #330; that PR's corrected build sends the right request, and this is why the answer still didn't change.

## Change

- `RAGPostResultProcessor` records `ai_instructions` on the stored Result's `json_results[0]`.
- `_try_serve_cache` treats a change in instructions like a change in items: a miss, so the model re-runs (the processor already deletes the previous ChatGPT Result before writing the new one).
- Rows written before the field existed read as "no instructions", so Galaxy's plain follow-up fetch after auto-RAG stays a cache hit and the 4.5.0.5 thrash fix holds.
- An empty stored Result (timed-out / errored first pass) is still served as a message on a plain fetch (DS-5681), but a deliberate retry with instructions re-runs.

## Tests

Four new cases in `swirl/tests/test_search_rag.py`, same monkeypatched style as the existing cache tests: regenerate when instructions differ; serve when they match (whitespace-tolerant); legacy rows without the field still serve on a plain fetch; empty rows re-run when instructions are supplied. File: 28 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
