### PR TITLE
DS-5737: lift the Django<6.0 cap (Django>=6.0.6,<7)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 requests
-Django>=5.2,<6.0
+# DS-5737: the <6.0 cap dated from Django 6.0's early admin changelist markup
+# change breaking the filter sidebar; 6.0.6+ lays it out correctly with our
+# theme (verified 6.0.8). Same floor as Enterprise. django-celery-beat 2.9
+# caps <6.1, so this resolves to 6.0.x until it moves.
+Django>=6.0.6,<7
 # DS-5737: was `django_restframework`, an empty 0.0.1 stub; the real Django
 # REST Framework only arrived transitively via drf-spectacular.
 djangorestframework

--- a/swirl/tests/test_admin_changelist_django6.py
+++ b/swirl/tests/test_admin_changelist_django6.py
@@ -1,0 +1,24 @@
+"""
+Admin changelist under Django 6: the filtered changelist renders with the
+filter sidebar markup. Django 6.0's changelist template change is why the old
+``Django<6.0`` cap existed; 6.0.6+ renders the sidebar correctly with the
+Community admin theme (checked in a browser against 6.0.8).
+"""
+import django
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_searchprovider_changelist_renders_with_filter_sidebar(client):
+    admin = User.objects.create_superuser("admin-dj6", "admin@example.com", "not-a-real-password")
+    client.force_login(admin)
+
+    response = client.get(reverse("admin:swirl_searchprovider_changelist"))
+
+    assert response.status_code == 200
+    assert django.VERSION >= (6, 0, 6), django.VERSION
+    html = response.content.decode()
+    assert 'class="module filtered" id="changelist"' in html
+    assert 'id="changelist-filter"' in html


### PR DESCRIPTION
## What

`Django>=5.2,<6.0` → `Django>=6.0.6,<7`, plus one render test. No other file changes.

## Why the cap existed, and why it can go

Sid capped Django below 6.0 in May (fcf52d9d) because Django 6.0 restructured the admin changelist filter markup and the filter sidebar collapsed below the list with the Community admin theme. Enterprise carries a compensating flex rule in its admin stylesheet and runs `Django>=6.0.6,<7`.

Checked here rather than assumed: a second instance on port 8001 from this branch, Django **6.0.8** (what `django-celery-beat 2.9`'s `<6.1` cap resolves to), with a copy of the local database, viewed in a real browser. The SearchProvider changelist renders with the filter sidebar beside the table (filter at x=1447, 240px wide; table at x=340, 1077px wide on a 1728px viewport). Neutralising Enterprise's flex rule in the page changed only the sidebar width (199px instead of 240px), so the layout bug is gone in 6.0.x and no CSS is ported. Floor at 6.0.6 like Enterprise so an early 6.0.x cannot resolve.

Note in passing: `swirl/static/admin/css/swirl-theme.css` is unreferenced in Community (the admin theme is inline in `templates/admin/base_site.html`); Enterprise links its copy. Dead file, separate cleanup.

## Validation

- Unit suite on Django 6.0.8 (3.14.7 scratch venv): 608 passed / 3 deselected (607 existing + the new render test); test warnings dropped from 102 to 1.
- New test `swirl/tests/test_admin_changelist_django6.py`: the filtered changelist returns 200 with the `module filtered` changelist and the `changelist-filter` element, and asserts Django ≥ 6.0.6.
- `pip check` clean; resolution vs develop changes only `django 5.2.17 → 6.0.8`.

Manual check before merge: open Manage SWIRL → SearchProviders and confirm the filter sidebar sits to the right of the table.

Independent of #1986 (requirements hygiene); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
